### PR TITLE
how to compile on Debian Jessie

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -5,5 +5,11 @@ It will be populated when building VelocyPack like this:
 (cd build && cmake -DCMAKE_BUILD_TYPE=Release -DBuildExamples=ON -DBuildTests=ON -DBuildTools=ON .. && make)
 ```
 
+On Debian Jessie (8) you have to use the g++ flags '-std=c++11 -std=gnu++11' to compile VelocyPack:
+
+```bash
+(cd build && cmake-DCMAKE_CXX_FLAGS="-std=c++11 -std=gnu++11" -DCMAKE_BUILD_TYPE=Release -DBuildExamples=ON -DBuildTests=ON -DBuildTools=ON .. && make)
+```
+
 You can remove the contents in this directory to build
 everything from scratch.

--- a/build/README.md
+++ b/build/README.md
@@ -8,7 +8,7 @@ It will be populated when building VelocyPack like this:
 On Debian Jessie (8) you have to use the g++ flags '-std=c++11 -std=gnu++11' to compile VelocyPack:
 
 ```bash
-(cd build && cmake-DCMAKE_CXX_FLAGS="-std=c++11 -std=gnu++11" -DCMAKE_BUILD_TYPE=Release -DBuildExamples=ON -DBuildTests=ON -DBuildTools=ON .. && make)
+(cd build && cmake -DCMAKE_CXX_FLAGS="-std=c++11 -std=gnu++11" -DCMAKE_BUILD_TYPE=Release -DBuildExamples=ON -DBuildTests=ON -DBuildTools=ON .. && make)
 ```
 
 You can remove the contents in this directory to build


### PR DESCRIPTION
Explained how to compile on Debian Jessie:

[  1%] Building CXX object CMakeFiles/velocypack.dir/src/velocypack-common.cpp.o
In file included from /usr/include/c++/4.9/chrono:35:0,
                 from /root/velocypack/src/velocypack-common.cpp:27:
/usr/include/c++/4.9/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.