### PR TITLE
Packed BCD long floats with base 100 exponent

### DIFF
--- a/VelocyPack.md
+++ b/VelocyPack.md
@@ -91,7 +91,7 @@ reference, for arrays and objects see below for details:
   - 0xc8-0xcf : positive long packed BCD-encoded float, V - 0xc7 bytes follow
                 that encode in a little endian way the length of the
                 mantissa in bytes. Directly after that follow 4 bytes
-                encoding the (power of 10) exponent, by which the mantissa
+                encoding the (power of 100) exponent, by which the mantissa
                 is to be multiplied, stored as little endian two's
                 complement signed 32-bit integer. After that, as many
                 bytes follow as the length information at the beginning

--- a/VelocyPack.md
+++ b/VelocyPack.md
@@ -527,22 +527,14 @@ even number of decimal digits. Note that the mantissa is stored in big
 endian form, to make parsing and dumping efficient. This leads to the
 "unholy nibble problem": When a JSON parser sees the beginning of a
 longish number, it does not know whether an even or odd number of digits
-follow. However, for efficiency reasons it wants to start writing bytes
-to the output as it reads the input. This is, where the exponent comes
-to the rescue, which is illustrated by the following example:
+follow. However, to reduce the amount of allocations the number of
+digits and the parity of the integral part is necessary anyway.
+This can be used to add a leading zero in the representation
+as seen in the following example:
 
     12345 decimal can be encoded as:
 
     0xc8 0x03 0x00 0x00 0x00 0x00 0x01 0x23 0x45
-    0xc8 0x03 0xff 0xff 0xff 0xff 0x12 0x34 0x50
-
-The former encoding puts a leading 0 in the first byte and uses exponent
-0, the latter encoding directly starts putting two decimal digits in one
-byte and then in the end has to "erase" the trailing 0 by using exponent
--1, encoded by the 4 byte sequence 0xff 0xff 0xff 0xff.
-
-There for the unholy nibble problem is solved and parsing (and indeed
-dumping) can be efficient.
 
 
 ## Custom types

--- a/VelocyPack.md
+++ b/VelocyPack.md
@@ -99,7 +99,6 @@ reference, for arrays and objects see below for details:
                 big-endian packed BCD
                 Example: 12345 decimal can be encoded as
                          0xc8 0x03 0x00 0x00 0x00 0x00 0x01 0x23 0x45
-                      or 0xc8 0x03 0xff 0xff 0xff 0xff 0x12 0x34 0x50
   - 0xd0-0xd7 : negative long packed BCD-encoded float, V - 0xcf bytes
                 follow that encode in a little endian way the length of
                 the mantissa in bytes. After that, same as positive long


### PR DESCRIPTION
Change the format of long packed BCD-encoded float to use exponent base 100 instead of 10. 
This means, for different exponents the mantissa needs to be shifted by full bytes instead of half bytes. The advantage of this approach is the possibility to use an incremented or decremented address instead of shifting the mantissa during arithmetic operations.
The downside of the base 100 exponent is that the "unholy nibble problems" remains unsolved. Hence the floating point can only be placed between two digits (full bytes), the parity of digits of the integral part must be known upfront. In the case of uneven digits a leading zero must be added. Nevertheless, the length and the parity of digits of the integral part must be known upfront to avoid additional allocations and copy operations. 
 