### PR TITLE
allow more control over padding

### DIFF
--- a/include/velocypack/Options.h
+++ b/include/velocypack/Options.h
@@ -45,10 +45,30 @@ struct CustomTypeHandler {
 };
 
 struct Options {
+  // Behavior to be applied when dumping VelocyPack values that cannot be
+  // expressed in JSON without data loss
   enum UnsupportedTypeBehavior {
+    // convert any non-JSON-representable value to null
     NullifyUnsupportedType,
+    // emit a JSON string "(non-representable type ...)"
     ConvertUnsupportedType,
+    // throw an exception for any non-JSON-representable value
     FailOnUnsupportedType
+  };
+
+  // Behavior to be applied when building VelocyPack Array/Object values
+  // with a Builder
+  enum PaddingBehavior {
+    // use padding - fill unused head bytes with zero-bytes (ASCII NUL) in
+    // order to avoid a later memmove
+    UsePadding,
+    // don't pad and do not fill any gaps with zero-bytes (ASCII NUL). 
+    // instead, memmove data down so there is no gap between the head bytes
+    // and the payload
+    NoPadding,
+    // pad in cases the Builder considers it useful, and don't pad in other
+    // cases when the Builder doesn't consider it useful
+    Flexible
   };
 
   Options() {}
@@ -56,7 +76,11 @@ struct Options {
   // Dumper behavior when a VPack value is serialized to JSON that
   // has no JSON equivalent
   UnsupportedTypeBehavior unsupportedTypeBehavior = FailOnUnsupportedType;
+ 
+  // Builder behavior w.r.t. padding or memmoving data
+  PaddingBehavior paddingBehavior = PaddingBehavior::Flexible;
 
+  // custom attribute translator for integer keys
   AttributeTranslator* attributeTranslator = nullptr;
 
   // custom type handler used for processing custom types by Dumper and Slicer

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -444,6 +444,15 @@ Builder& Builder::closeArray(ValueLength tos, std::vector<ValueLength>& index) {
     offsetSize = 8;
   }
 
+  if (offsetSize < 8 &&
+      !needIndexTable && 
+      options->paddingBehavior == Options::PaddingBehavior::UsePadding) {
+    // if we are allowed to use padding, we will pad to 8 bytes anyway. as we are not
+    // using an index table, we can also use type 0x05 for all Arrays without making
+    // things worse space-wise
+    offsetSize = 8;
+  }
+
   // Maybe we need to move down data:
   if (offsetSize == 1 || offsetSize == 2) {
     // check if one of the first entries in the array is ValueType::None 

--- a/tests/testsBuilder.cpp
+++ b/tests/testsBuilder.cpp
@@ -2774,6 +2774,12 @@ TEST(BuilderTest, UsePaddingForOneByteArray) {
     return b.slice().start();
   };
 
+  auto test = [&b]() {
+    for (uint64_t i = 0; i < 20; ++i) {
+      ASSERT_EQ(i, b.slice().at(i).getUInt());
+    }
+  };
+
   options.paddingBehavior = Options::PaddingBehavior::NoPadding;
   uint8_t const* data = build();
 
@@ -2786,6 +2792,8 @@ TEST(BuilderTest, UsePaddingForOneByteArray) {
   ASSERT_EQ(0x33, data[6]);
   ASSERT_EQ(0x34, data[7]);
   ASSERT_EQ(0x35, data[8]);
+
+  test();
   
   options.paddingBehavior = Options::PaddingBehavior::Flexible;
   data = build();
@@ -2799,6 +2807,8 @@ TEST(BuilderTest, UsePaddingForOneByteArray) {
   ASSERT_EQ(0x33, data[6]);
   ASSERT_EQ(0x34, data[7]);
   ASSERT_EQ(0x35, data[8]);
+  
+  test();
  
   options.paddingBehavior = Options::PaddingBehavior::UsePadding;
   data = build();
@@ -2814,6 +2824,8 @@ TEST(BuilderTest, UsePaddingForOneByteArray) {
   ASSERT_EQ(0x00, data[8]);
   ASSERT_EQ(0x30, data[9]);
   ASSERT_EQ(0x31, data[10]);
+  
+  test();
 }
 
 TEST(BuilderTest, UsePaddingForTwoByteArray) {
@@ -2831,6 +2843,12 @@ TEST(BuilderTest, UsePaddingForTwoByteArray) {
     b.close();
     return b.slice().start();
   };
+  
+  auto test = [&b]() {
+    for (uint64_t i = 0; i < 260; ++i) {
+      ASSERT_EQ(i, b.slice().at(i).getUInt());
+    }
+  };
 
   options.paddingBehavior = Options::PaddingBehavior::NoPadding;
   uint8_t const* data = build();
@@ -2844,6 +2862,8 @@ TEST(BuilderTest, UsePaddingForTwoByteArray) {
   ASSERT_EQ(0x31, data[6]);
   ASSERT_EQ(0x32, data[7]);
   ASSERT_EQ(0x33, data[8]);
+
+  test();
   
   options.paddingBehavior = Options::PaddingBehavior::Flexible;
   data = build();
@@ -2860,6 +2880,8 @@ TEST(BuilderTest, UsePaddingForTwoByteArray) {
   ASSERT_EQ(0x30, data[9]);
   ASSERT_EQ(0x31, data[10]);
 
+  test();
+
   options.paddingBehavior = Options::PaddingBehavior::UsePadding;
   data = build();
 
@@ -2874,6 +2896,8 @@ TEST(BuilderTest, UsePaddingForTwoByteArray) {
   ASSERT_EQ(0x00, data[8]);
   ASSERT_EQ(0x30, data[9]);
   ASSERT_EQ(0x31, data[10]);
+
+  test();
 }
 
 TEST(BuilderTest, UsePaddingForEquallySizedArray) {
@@ -2891,6 +2915,12 @@ TEST(BuilderTest, UsePaddingForEquallySizedArray) {
     b.close();
     return b.slice().start();
   };
+  
+  auto test = [&b]() {
+    for (uint64_t i = 0; i < 3; ++i) {
+      ASSERT_EQ(i, b.slice().at(i).getUInt());
+    }
+  };
 
   options.paddingBehavior = Options::PaddingBehavior::NoPadding;
   uint8_t const* data = build();
@@ -2900,6 +2930,8 @@ TEST(BuilderTest, UsePaddingForEquallySizedArray) {
   ASSERT_EQ(0x30, data[2]);
   ASSERT_EQ(0x31, data[3]);
   ASSERT_EQ(0x32, data[4]);
+
+  test();
   
   options.paddingBehavior = Options::PaddingBehavior::Flexible;
   data = build();
@@ -2909,6 +2941,8 @@ TEST(BuilderTest, UsePaddingForEquallySizedArray) {
   ASSERT_EQ(0x30, data[2]);
   ASSERT_EQ(0x31, data[3]);
   ASSERT_EQ(0x32, data[4]);
+
+  test();
  
   options.paddingBehavior = Options::PaddingBehavior::UsePadding;
   data = build();
@@ -2925,6 +2959,8 @@ TEST(BuilderTest, UsePaddingForEquallySizedArray) {
   ASSERT_EQ(0x30, data[9]);
   ASSERT_EQ(0x31, data[10]);
   ASSERT_EQ(0x32, data[11]);
+
+  test();
 }
 
 TEST(BuilderTest, UsePaddingForOneByteObject) {
@@ -2943,6 +2979,14 @@ TEST(BuilderTest, UsePaddingForOneByteObject) {
     b.close();
     return b.slice().start();
   };
+  
+  auto test = [&b]() {
+    for (uint64_t i = 0; i < 10; ++i) {
+      std::string key = std::string("test") + std::to_string(i);
+      ASSERT_TRUE(b.slice().hasKey(key));
+      ASSERT_EQ(i, b.slice().get(key).getUInt());
+    }
+  };
 
   options.paddingBehavior = Options::PaddingBehavior::NoPadding;
   uint8_t const* data = build();
@@ -2958,6 +3002,8 @@ TEST(BuilderTest, UsePaddingForOneByteObject) {
   ASSERT_EQ(0x30, data[8]);
   ASSERT_EQ(0x30, data[9]);
 
+  test();
+
   options.paddingBehavior = Options::PaddingBehavior::Flexible;
   data = build();
   
@@ -2971,6 +3017,8 @@ TEST(BuilderTest, UsePaddingForOneByteObject) {
   ASSERT_EQ(0x74, data[7]);
   ASSERT_EQ(0x30, data[8]);
   ASSERT_EQ(0x30, data[9]);
+
+  test();
  
   options.paddingBehavior = Options::PaddingBehavior::UsePadding;
   data = build();
@@ -2986,6 +3034,8 @@ TEST(BuilderTest, UsePaddingForOneByteObject) {
   ASSERT_EQ(0x00, data[8]);
   ASSERT_EQ(0x45, data[9]);
   ASSERT_EQ(0x74, data[10]);
+  
+  test();
 }
 
 TEST(BuilderTest, UsePaddingForTwoByteObject) {
@@ -3004,6 +3054,14 @@ TEST(BuilderTest, UsePaddingForTwoByteObject) {
     b.close();
     return b.slice().start();
   };
+  
+  auto test = [&b]() {
+    for (uint64_t i = 0; i < 260; ++i) {
+      std::string key = std::string("test") + std::to_string(i);
+      ASSERT_TRUE(b.slice().hasKey(key));
+      ASSERT_EQ(i, b.slice().get(key).getUInt());
+    }
+  };
 
   options.paddingBehavior = Options::PaddingBehavior::NoPadding;
   uint8_t const* data = build();
@@ -3019,6 +3077,8 @@ TEST(BuilderTest, UsePaddingForTwoByteObject) {
   ASSERT_EQ(0x73, data[8]);
   ASSERT_EQ(0x74, data[9]);
 
+  test();
+
   options.paddingBehavior = Options::PaddingBehavior::Flexible;
   data = build();
   
@@ -3033,6 +3093,8 @@ TEST(BuilderTest, UsePaddingForTwoByteObject) {
   ASSERT_EQ(0x00, data[8]);
   ASSERT_EQ(0x45, data[9]);
   ASSERT_EQ(0x74, data[10]);
+  
+  test();
  
   options.paddingBehavior = Options::PaddingBehavior::UsePadding;
   data = build();
@@ -3048,6 +3110,8 @@ TEST(BuilderTest, UsePaddingForTwoByteObject) {
   ASSERT_EQ(0x00, data[8]);
   ASSERT_EQ(0x45, data[9]);
   ASSERT_EQ(0x74, data[10]);
+  
+  test();
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/testsBuilder.cpp
+++ b/tests/testsBuilder.cpp
@@ -2876,6 +2876,57 @@ TEST(BuilderTest, UsePaddingForTwoByteArray) {
   ASSERT_EQ(0x31, data[10]);
 }
 
+TEST(BuilderTest, UsePaddingForEquallySizedArray) {
+  Options options;
+  Builder b(&options);
+
+  auto build = [&b]() {
+    b.clear();
+    b.openArray();
+
+    for (size_t i = 0; i < 3; ++i) {
+      b.add(Value(i));
+    }
+
+    b.close();
+    return b.slice().start();
+  };
+
+  options.paddingBehavior = Options::PaddingBehavior::NoPadding;
+  uint8_t const* data = build();
+
+  ASSERT_EQ(0x02, data[0]);
+  ASSERT_EQ(0x05, data[1]);
+  ASSERT_EQ(0x30, data[2]);
+  ASSERT_EQ(0x31, data[3]);
+  ASSERT_EQ(0x32, data[4]);
+  
+  options.paddingBehavior = Options::PaddingBehavior::Flexible;
+  data = build();
+
+  ASSERT_EQ(0x02, data[0]);
+  ASSERT_EQ(0x05, data[1]);
+  ASSERT_EQ(0x30, data[2]);
+  ASSERT_EQ(0x31, data[3]);
+  ASSERT_EQ(0x32, data[4]);
+ 
+  options.paddingBehavior = Options::PaddingBehavior::UsePadding;
+  data = build();
+
+  ASSERT_EQ(0x05, data[0]);
+  ASSERT_EQ(0x0c, data[1]);
+  ASSERT_EQ(0x00, data[2]);
+  ASSERT_EQ(0x00, data[3]);
+  ASSERT_EQ(0x00, data[4]);
+  ASSERT_EQ(0x00, data[5]);
+  ASSERT_EQ(0x00, data[6]);
+  ASSERT_EQ(0x00, data[7]);
+  ASSERT_EQ(0x00, data[8]);
+  ASSERT_EQ(0x30, data[9]);
+  ASSERT_EQ(0x31, data[10]);
+  ASSERT_EQ(0x32, data[11]);
+}
+
 TEST(BuilderTest, UsePaddingForOneByteObject) {
   Options options;
   Builder b(&options);

--- a/tests/testsValidator.cpp
+++ b/tests/testsValidator.cpp
@@ -1542,6 +1542,36 @@ TEST(ValidatorTest, ArrayEightByteIndexedRepeatedValues) {
   ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
 }
 
+TEST(ValidatorTest, ArrayOneByteWithExtraPadding) {
+  Options options;
+  options.paddingBehavior = Options::PaddingBehavior::UsePadding;
+  Builder b(&options);
+  b.openArray(false);
+  b.add(Value(1));
+  b.add(Value(2));
+  b.add(Value(3));
+  b.close();
+
+  Slice s = b.slice();
+  uint8_t const* data = s.start();
+
+  ASSERT_EQ(0x05, data[0]);
+  ASSERT_EQ(0x0c, data[1]);
+  ASSERT_EQ(0x00, data[2]);
+  ASSERT_EQ(0x00, data[3]);
+  ASSERT_EQ(0x00, data[4]);
+  ASSERT_EQ(0x00, data[5]);
+  ASSERT_EQ(0x00, data[6]);
+  ASSERT_EQ(0x00, data[7]);
+  ASSERT_EQ(0x00, data[8]);
+  ASSERT_EQ(0x31, data[9]);
+  ASSERT_EQ(0x32, data[10]);
+  ASSERT_EQ(0x33, data[11]);
+  
+  Validator validator;
+  ASSERT_TRUE(validator.validate(data, s.byteSize()));
+}
+
 TEST(ValidatorTest, ArrayCompact) {
   std::string const value("\x13\x04\x18\x01", 4);
 


### PR DESCRIPTION
Add option `paddingBehavior` to `Options` class, with the following enum values:
```
   // Behavior to be applied when building VelocyPack Array/Object values
   // with a Builder
   enum PaddingBehavior {
     // use padding - fill unused head bytes with zero-bytes (ASCII NUL) in
     // order to avoid a later memmove
     UsePadding,
     // don't pad and do not fill any gaps with zero-bytes (ASCII NUL). 
     // instead, memmove data down so there is no gap between the head bytes
     // and the payload
     NoPadding,
     // pad in cases the Builder considers it useful, and don't pad in other
     // cases when the Builder doesn't consider it useful
     Flexible
   };  
```
The default behavior is `Flexible`, meaning the `Builder` is making the same choices about padding as in previous versions. Setting the option `NoPadding` will however turn off padding wherever possible, and `UsePadding` will make the `Builder` use padding.