### PR TITLE
Feature/make builder move noexcept

### DIFF
--- a/include/velocypack/Buffer.h
+++ b/include/velocypack/Buffer.h
@@ -307,6 +307,7 @@ class Buffer {
 };
 
 typedef Buffer<char> CharBuffer;
+typedef Buffer<uint8_t> UInt8Buffer;
 
 template<typename T>
 struct BufferNonDeleter {

--- a/include/velocypack/Builder.h
+++ b/include/velocypack/Builder.h
@@ -104,8 +104,8 @@ class Builder {
 
   Builder(Builder const& that);
   Builder& operator=(Builder const& that);
-  Builder(Builder&& that);
-  Builder& operator=(Builder&& that);
+  Builder(Builder&& that) noexcept;
+  Builder& operator=(Builder&& that) noexcept;
 
   // get a const reference to the Builder's Buffer object
   std::shared_ptr<Buffer<uint8_t>> const& buffer() const { return _buffer; }
@@ -114,10 +114,10 @@ class Builder {
   // is unusable
   std::shared_ptr<Buffer<uint8_t>> steal() {
     // After a steal the Builder is broken!
-    std::shared_ptr<Buffer<uint8_t>> res = _buffer;
-    _buffer.reset();
+    std::shared_ptr<Buffer<uint8_t>> res(std::move(_buffer));
     _bufferPtr = nullptr;
     _pos = 0;
+    _keyWritten = false;
     return res;
   }
 
@@ -801,7 +801,7 @@ struct ObjectBuilder final : public BuilderContainer,
     } catch (...) {
       // destructors must not throw. however, we can at least
       // signal something is very wrong in debug mode
-      VELOCYPACK_ASSERT(false);
+      VELOCYPACK_ASSERT(builder->isClosed());
     }
   }
 };
@@ -830,7 +830,7 @@ struct ArrayBuilder final : public BuilderContainer,
     } catch (...) {
       // destructors must not throw. however, we can at least
       // signal something is very wrong in debug mode
-      VELOCYPACK_ASSERT(false);
+      VELOCYPACK_ASSERT(builder->isClosed());
     }
   }
 };

--- a/include/velocypack/Options.h
+++ b/include/velocypack/Options.h
@@ -39,7 +39,7 @@ struct Options;
 class Slice;
 
 struct CustomTypeHandler {
-  virtual ~CustomTypeHandler() {}
+  virtual ~CustomTypeHandler() = default;
   virtual void dump(Slice const&, Dumper*, Slice const&);
   virtual std::string toString(Slice const&, Options const*, Slice const&);
 };

--- a/include/velocypack/Sink.h
+++ b/include/velocypack/Sink.h
@@ -42,7 +42,7 @@ struct Sink {
   Sink(Sink const&) = delete;
   Sink& operator=(Sink const&) = delete;
 
-  virtual ~Sink() {}
+  virtual ~Sink() = default;
   virtual void push_back(char c) = 0;
   virtual void append(std::string const& p) = 0;
   virtual void append(char const* p) = 0;

--- a/include/velocypack/Slice.h
+++ b/include/velocypack/Slice.h
@@ -47,13 +47,12 @@
 namespace arangodb {
 namespace velocypack {
 
+// This class provides read only access to a VPack value, it is
+// intentionally light-weight (only one pointer value), such that
+// it can easily be used to traverse larger VPack values.
+
+// A Slice does not own the VPack data it points to!
 class Slice {
-  // This class provides read only access to a VPack value, it is
-  // intentionally light-weight (only one pointer value), such that
-  // it can easily be used to traverse larger VPack values.
-
-  // A Slice does not own the VPack data it points to!
-
   friend class Builder;
   friend class ArrayIterator;
   friend class ObjectIterator;
@@ -1104,6 +1103,9 @@ class Slice {
     return value;
   }
 };
+
+static_assert(!std::is_polymorphic<Slice>::value, "Slice must not be polymorphic");
+static_assert(!std::has_virtual_destructor<Slice>::value, "Slice must not have virtual dtor");
 
 }  // namespace arangodb::velocypack
 }  // namespace arangodb

--- a/include/velocypack/velocypack-aliases.h
+++ b/include/velocypack/velocypack-aliases.h
@@ -71,6 +71,7 @@ using VPackNormalizedCompare = arangodb::velocypack::NormalizedCompare;
 #ifndef VELOCYPACK_ALIAS_BUFFER
 #define VELOCYPACK_ALIAS_BUFFER
 using VPackCharBuffer = arangodb::velocypack::CharBuffer;
+using VPackBufferUInt8 = arangodb::velocypack::UInt8Buffer;
 template<typename T> using VPackBuffer = arangodb::velocypack::Buffer<T>;
 #endif
 #endif

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -211,28 +211,22 @@ Builder& Builder::operator=(Builder const& that) {
   return *this;
 }
 
-Builder::Builder(Builder&& that) {
-  if (VELOCYPACK_UNLIKELY(!that.isClosed())) {
-    throw Exception(Exception::InternalError, "Cannot move an open Builder");
-  }
-  _buffer = that._buffer;
-  _bufferPtr = _buffer.get();
-  _start = _bufferPtr->data();
-  _pos = that._pos;
-  _stack.clear();
-  _stack.swap(that._stack);
-  _index.clear();
-  _index.swap(that._index);
-  _keyWritten = that._keyWritten;
-  options = that.options;
+Builder::Builder(Builder&& that) noexcept
+    : _buffer(that._buffer),
+      _bufferPtr(_buffer.get()),
+      _start(_bufferPtr->data()),
+      _pos(that._pos),
+      _stack(std::move(that._stack)),
+      _index(std::move(that._index)),
+      _keyWritten(that._keyWritten),
+      options(that.options) {
   that._pos = 0;
+  that._stack.clear();
+  that._index.clear();
   that._keyWritten = false;
 }
 
-Builder& Builder::operator=(Builder&& that) {
-  if (VELOCYPACK_UNLIKELY(!that.isClosed())) {
-    throw Exception(Exception::InternalError, "Cannot move an open Builder");
-  }
+Builder& Builder::operator=(Builder&& that) noexcept {
   if (this != &that) {
     _buffer = that._buffer;
     _bufferPtr = _buffer.get();

--- a/tests/testsBuilder.cpp
+++ b/tests/testsBuilder.cpp
@@ -317,8 +317,8 @@ TEST(BuilderTest, MoveConstructOpenObject) {
   b.openObject();
   ASSERT_FALSE(b.isClosed());
 
-  Builder a;
-  ASSERT_VELOCYPACK_EXCEPTION(Builder(std::move(b)), Exception::InternalError);
+  Builder a(std::move(b));
+  ASSERT_FALSE(a.isClosed());
 }
 
 TEST(BuilderTest, MoveConstructOpenArray) {
@@ -326,7 +326,9 @@ TEST(BuilderTest, MoveConstructOpenArray) {
   b.openArray();
   ASSERT_FALSE(b.isClosed());
 
-  ASSERT_VELOCYPACK_EXCEPTION(Builder(std::move(b)), Exception::InternalError);
+  Builder a(std::move(b));
+  ASSERT_FALSE(a.isClosed());
+  ASSERT_TRUE(b.isClosed());
 }
 
 TEST(BuilderTest, MoveAssignOpenObject) {
@@ -335,7 +337,9 @@ TEST(BuilderTest, MoveAssignOpenObject) {
   ASSERT_FALSE(b.isClosed());
 
   Builder a;
-  ASSERT_VELOCYPACK_EXCEPTION(a = std::move(b), Exception::InternalError);
+  a = std::move(b);
+  ASSERT_FALSE(a.isClosed());
+  ASSERT_TRUE(b.isClosed());
 }
 
 TEST(BuilderTest, MoveAssignOpenArray) {
@@ -344,7 +348,9 @@ TEST(BuilderTest, MoveAssignOpenArray) {
   ASSERT_FALSE(b.isClosed());
 
   Builder a;
-  ASSERT_VELOCYPACK_EXCEPTION(a = std::move(b), Exception::InternalError);
+  a = std::move(b);
+  ASSERT_FALSE(a.isClosed());
+  ASSERT_TRUE(b.isClosed());
 }
 
 TEST(BuilderTest, Move) {

--- a/tests/testsBuilder.cpp
+++ b/tests/testsBuilder.cpp
@@ -477,6 +477,32 @@ TEST(BuilderTest, UsingExistingBuffer) {
   ASSERT_EQ("the-foxx", b5.slice().copyString());
 }
 
+TEST(BuilderTest, AfterStolen) {
+  Builder b1;
+  b1.add(Value("the-quick-brown-fox-jumped-over-the-lazy-dog"));
+
+  // sets the shared_ptr of the Builder's Buffer to nullptr
+  ASSERT_NE(nullptr, b1.steal());
+
+  // copy-construct
+  Builder b2(b1); 
+  ASSERT_EQ(nullptr, b2.steal());
+
+  // copy-assign
+  Builder b3;
+  b3 = b2; 
+  ASSERT_EQ(nullptr, b3.steal());
+
+  // move-construct
+  Builder b4(std::move(b3));
+  ASSERT_EQ(nullptr, b4.steal());
+
+  // move-assign
+  Builder b5;
+  b5 = std::move(b4);
+  ASSERT_EQ(nullptr, b5.steal());
+}
+
 TEST(BuilderTest, StealBuffer) {
   Builder b;
   b.openArray();

--- a/tests/testsParser.cpp
+++ b/tests/testsParser.cpp
@@ -2170,7 +2170,7 @@ TEST(ParserTest, DuplicateAttributesDisallowed) {
                               Exception::DuplicateAttributeName);
 }
 
-TEST(ParserTest, DuplicateAttributesDisallowedUnsortedObject) {
+TEST(ParserTest, DuplicateAttributesDisallowedUnsortedInput) {
   Options options;
   options.checkAttributeUniqueness = true;
 
@@ -2208,6 +2208,60 @@ TEST(ParserTest, DuplicateSubAttributesDisallowed) {
   Parser parser(&options);
   ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value),
                               Exception::DuplicateAttributeName);
+}
+
+TEST(ParserTest, DuplicateAttributesSortedObjects) {
+  Options options;
+  options.buildUnindexedObjects = false;
+  options.checkAttributeUniqueness = true;
+
+  for (std::size_t i = 1; i < 20; ++i) {
+    std::string value;
+    value.push_back('{');
+    for (std::size_t j = 0; j < i; ++j) {
+      if (j != 0) {
+        value.push_back(',');
+      }
+      value.push_back('"');
+      value.append("test");
+      value.append(std::to_string(j));
+      value.append("\":true");
+    }
+    // now push a duplicate
+    value.append(",\"test0\":false");
+    value.push_back('}');
+  
+    Parser parser(&options);
+    ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value),
+                                Exception::DuplicateAttributeName);
+  }
+}
+
+TEST(ParserTest, DuplicateAttributesUnsortedObjects) {
+  Options options;
+  options.buildUnindexedObjects = true;
+  options.checkAttributeUniqueness = true;
+
+  for (std::size_t i = 1; i < 20; ++i) {
+    std::string value;
+    value.push_back('{');
+    for (std::size_t j = 0; j < i; ++j) {
+      if (j != 0) {
+        value.push_back(',');
+      }
+      value.push_back('"');
+      value.append("test");
+      value.append(std::to_string(j));
+      value.append("\":true");
+    }
+    // now push a duplicate
+    value.append(",\"test0\":false");
+    value.push_back('}');
+  
+    Parser parser(&options);
+    ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value),
+                                Exception::DuplicateAttributeName);
+  }
 }
 
 TEST(ParserTest, FromJsonString) {

--- a/tests/testsParser.cpp
+++ b/tests/testsParser.cpp
@@ -2237,6 +2237,30 @@ TEST(ParserTest, DuplicateAttributesSortedObjects) {
   }
 }
 
+TEST(ParserTest, NoDuplicateAttributesSortedObjects) {
+  Options options;
+  options.buildUnindexedObjects = false;
+  options.checkAttributeUniqueness = true;
+
+  for (std::size_t i = 1; i < 20; ++i) {
+    std::string value;
+    value.push_back('{');
+    for (std::size_t j = 0; j < i; ++j) {
+      if (j != 0) {
+        value.push_back(',');
+      }
+      value.push_back('"');
+      value.append("test");
+      value.append(std::to_string(j));
+      value.append("\":true");
+    }
+    value.push_back('}');
+  
+    Parser parser(&options);
+    ASSERT_TRUE(parser.parse(value) > 0);
+  }
+}
+
 TEST(ParserTest, DuplicateAttributesUnsortedObjects) {
   Options options;
   options.buildUnindexedObjects = true;
@@ -2261,6 +2285,30 @@ TEST(ParserTest, DuplicateAttributesUnsortedObjects) {
     Parser parser(&options);
     ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value),
                                 Exception::DuplicateAttributeName);
+  }
+}
+
+TEST(ParserTest, NoDuplicateAttributesUnsortedObjects) {
+  Options options;
+  options.buildUnindexedObjects = true;
+  options.checkAttributeUniqueness = true;
+
+  for (std::size_t i = 1; i < 20; ++i) {
+    std::string value;
+    value.push_back('{');
+    for (std::size_t j = 0; j < i; ++j) {
+      if (j != 0) {
+        value.push_back(',');
+      }
+      value.push_back('"');
+      value.append("test");
+      value.append(std::to_string(j));
+      value.append("\":true");
+    }
+    value.push_back('}');
+  
+    Parser parser(&options);
+    ASSERT_TRUE(parser.parse(value) > 0);
   }
 }
 


### PR DESCRIPTION
- `Builder` move construct and move assign are now noexcept
- `Builder` using an existing `Buffer` object can now be created without a heap allocation