### PR TITLE
Make exampleCustom.cpp work

### DIFF
--- a/examples/exampleCustom.cpp
+++ b/examples/exampleCustom.cpp
@@ -90,15 +90,15 @@ int main(int, char* []) {
 
   // now print 'custom1':
   std::cout << "'custom1': byteSize: " << s.get("custom1").byteSize()
-            << ", JSON: " << s.get("custom1").toJson() << std::endl;
+            << ", JSON: " << s.get("custom1").toJson(&options) << std::endl;
 
   // and 'custom2':
   std::cout << "'custom2': byteSize: " << s.get("custom2").byteSize()
-            << ", JSON: " << s.get("custom2").toJson() << std::endl;
+            << ", JSON: " << s.get("custom2").toJson(&options) << std::endl;
 
   // and 'custom3':
   std::cout << "'custom3': byteSize: " << s.get("custom3").byteSize()
-            << ", JSON: " << s.get("custom3").toJson() << std::endl;
+            << ", JSON: " << s.get("custom3").toJson(&options) << std::endl;
   
   VELOCYPACK_GLOBAL_EXCEPTION_CATCH
 }


### PR DESCRIPTION
Did this ever work? Without this change I get an exception [here](https://github.com/arangodb/velocypack/blob/27d5366b995ad5931418cabeb3b364ace2d8b176/src/Dumper.cpp#L543).

Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.

Code changes and contributions in the VelocyPack library should use 
the "Google" style and conventions as used by *clang-format*. 
