### PR TITLE
Unpack Tuple

### DIFF
--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -49,8 +49,8 @@ class ArrayIterator : public std::iterator<std::forward_iterator_tag, Slice> {
 
   explicit ArrayIterator(Slice slice)
       : _slice(slice), _size(0), _position(0), _current(nullptr), _first(nullptr) {
-    
-    uint8_t const head = slice.head();     
+
+    uint8_t const head = slice.head();
 
     if (VELOCYPACK_UNLIKELY(slice.type(head) != ValueType::Array)) {
       throw Exception(Exception::InvalidValueType, "Expecting Array slice");
@@ -102,13 +102,13 @@ class ArrayIterator : public std::iterator<std::forward_iterator_tag, Slice> {
     // be performed by Slice::getNthOffset()
     return Slice(_slice.begin() + _slice.getNthOffset(_position));
   }
-  
-  ArrayIterator begin() const { 
+
+  ArrayIterator begin() const {
     auto it = ArrayIterator(*this);
     it._position = 0;
     return it;
   }
-  
+
   ArrayIterator end() const {
     auto it = ArrayIterator(*this);
     it._position = it._size;
@@ -148,16 +148,35 @@ class ArrayIterator : public std::iterator<std::forward_iterator_tag, Slice> {
       } else {
         _position += count;
         _current = _slice.at(_position).start();
-      } 
+      }
     }
   }
-    
+
   inline void reset() {
     _position = 0;
     _current = _first;
   }
 
+  template<typename... Ts>
+  std::tuple<Ts...> unpackTuple() {
+    return unpackTupleInternal(unpack_helper<Ts...>{});
+  }
+
  private:
+  template<typename...>
+  struct unpack_helper {};
+
+  template<typename T, typename... Ts>
+  std::tuple<T, Ts...> unpackTupleInternal(unpack_helper<T, Ts...>) {
+    auto slice = value(); // this does out-of-bounds checking
+    next();
+    return std::tuple_cat(std::make_tuple(slice.extract<T>()), unpackTupleInternal(unpack_helper<Ts...>{}));
+  }
+
+  std::tuple<> unpackTupleInternal(unpack_helper<>) const {
+    return std::make_tuple<>();
+  }
+
   Slice _slice;
   ValueLength _size;
   ValueLength _position;
@@ -183,8 +202,8 @@ class ObjectIterator : public std::iterator<std::forward_iterator_tag, ObjectIte
   // index. The default `false` is to use the index if it is there.
   explicit ObjectIterator(Slice slice, bool useSequentialIteration = false)
       : _slice(slice), _size(0), _position(0), _current(nullptr), _first(nullptr) {
-    
-    uint8_t const head = slice.head();     
+
+    uint8_t const head = slice.head();
 
     if (VELOCYPACK_UNLIKELY(slice.type(head) != ValueType::Object)) {
       throw Exception(Exception::InvalidValueType, "Expecting Object slice");
@@ -240,8 +259,8 @@ class ObjectIterator : public std::iterator<std::forward_iterator_tag, ObjectIte
     Slice key(_slice.getNthKeyUntranslated(_position));
     return ObjectPair(key.makeKey(), Slice(key.begin() + key.byteSize()));
   }
-  
-  ObjectIterator begin() const { 
+
+  ObjectIterator begin() const {
     auto it = ObjectIterator(*this);
     it._position = 0;
     return it;
@@ -288,7 +307,7 @@ class ObjectIterator : public std::iterator<std::forward_iterator_tag, ObjectIte
   inline bool isFirst() const noexcept { return (_position == 0); }
 
   inline bool isLast() const noexcept { return (_position + 1 >= _size); }
-  
+
   inline void reset() {
     _position = 0;
     _current = _first;

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -26,6 +26,7 @@
 #define VELOCYPACK_ITERATOR_H 1
 
 #include <iosfwd>
+#include <tuple>
 
 #include "velocypack/velocypack-common.h"
 #include "velocypack/Exception.h"

--- a/include/velocypack/Slice.h
+++ b/include/velocypack/Slice.h
@@ -34,6 +34,7 @@
 #include <iterator>
 #include <algorithm>
 #include <functional>
+#include <tuple>
 #include <type_traits>
 
 #if __cplusplus >= 201703L

--- a/include/velocypack/Slice.h
+++ b/include/velocypack/Slice.h
@@ -53,6 +53,9 @@
 namespace arangodb {
 namespace velocypack {
 
+template<typename, typename = void>
+struct Extractor;
+
 // This class provides read only access to a VPack value, it is
 // intentionally light-weight (only one pointer value), such that
 // it can easily be used to traverse larger VPack values.
@@ -75,7 +78,7 @@ class Slice {
   static constexpr uint64_t defaultSeed64 = 0xdeadbeef;
   static constexpr uint32_t defaultSeed32 = 0xdeadbeef;
   static constexpr uint64_t defaultSeed = defaultSeed64;
- 
+
   static uint8_t const noneSliceData[];
   static uint8_t const illegalSliceData[];
   static uint8_t const nullSliceData[];
@@ -94,18 +97,18 @@ class Slice {
   // creates a Slice from a pointer to a uint8_t array
   explicit constexpr Slice(uint8_t const* start) noexcept
       : _start(start) {}
-  
+
   // No destructor, does not take part in memory management
 
   // creates a slice of type None
   static constexpr Slice noneSlice() noexcept { return Slice(noneSliceData); }
-  
+
   // creates a slice of type Illegal
   static constexpr Slice illegalSlice() noexcept { return Slice(illegalSliceData); }
 
   // creates a slice of type Null
   static constexpr Slice nullSlice() noexcept { return Slice(nullSliceData); }
-  
+
   // creates a slice of type Boolean with the relevant value
   static constexpr Slice booleanSlice(bool value) noexcept { return value ? trueSlice() : falseSlice(); }
 
@@ -114,19 +117,19 @@ class Slice {
 
   // creates a slice of type Boolean with true value
   static constexpr Slice trueSlice() noexcept { return Slice(trueSliceData); }
-  
+
   // creates a slice of type Smallint(0)
   static constexpr Slice zeroSlice() noexcept { return Slice(zeroSliceData); }
-  
+
   // creates a slice of type String, empty
   static constexpr Slice emptyStringSlice() noexcept { return Slice(emptyStringSliceData); }
-  
+
   // creates a slice of type Array, empty
   static constexpr Slice emptyArraySlice() noexcept { return Slice(emptyArraySliceData); }
-  
+
   // creates a slice of type Object, empty
   static constexpr Slice emptyObjectSlice() noexcept { return Slice(emptyObjectSliceData); }
-  
+
   // creates a slice of type MinKey
   static constexpr Slice minKeySlice() noexcept { return Slice(minKeySliceData); }
 
@@ -294,7 +297,7 @@ class Slice {
 
   // check if slice is a None object
   constexpr bool isNone() const noexcept { return isType(ValueType::None); }
-  
+
   // check if slice is an Illegal object
   constexpr bool isIllegal() const noexcept { return isType(ValueType::Illegal); }
 
@@ -365,12 +368,12 @@ class Slice {
 
   // check if slice is any Number-type object
   constexpr bool isNumber() const noexcept { return isInteger() || isDouble(); }
- 
+
   // check if slice is convertible to a variable of a certain
-  // number type 
+  // number type
   template<typename T>
   bool isNumber() const noexcept {
-    try { 
+    try {
       if (std::is_integral<T>()) {
         if (std::is_signed<T>()) {
           // signed integral type
@@ -396,7 +399,7 @@ class Slice {
           return (v <= static_cast<uint64_t>((std::numeric_limits<T>::max)()));
         }
       }
-      
+
       // floating point type
       return isNumber();
     } catch (...) {
@@ -495,7 +498,7 @@ class Slice {
 
     return readIntegerNonEmpty<ValueLength>(start() + end - offsetSize, offsetSize);
   }
-  
+
   // extract a key from an Object at the specified index
   // - 0x0a      : empty object
   // - 0x0b      : object with 1-byte index table entries, sorted by attribute
@@ -530,7 +533,7 @@ class Slice {
     Slice key = getNthKeyUntranslated(index);
     return Slice(key.start() + key.byteSize());
   }
-  
+
   // extract the nth value from an Object
   Slice getNthValue(ValueLength index) const {
     Slice key = getNthKeyUntranslated(index);
@@ -541,13 +544,13 @@ class Slice {
   // returns a Slice(ValueType::None) if not found
   template<typename ForwardIterator>
   typename std::enable_if<
-      std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<ForwardIterator>::iterator_category>::value, 
+      std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<ForwardIterator>::iterator_category>::value,
       Slice>::type get(ForwardIterator begin, ForwardIterator end,
                        bool resolveExternals = false) const {
 
     if (VELOCYPACK_UNLIKELY(begin == end)) {
       throw Exception(Exception::InvalidAttributePath);
-    }    
+    }
     // use ourselves as the starting point
     Slice last(start());
     if (resolveExternals) {
@@ -555,10 +558,10 @@ class Slice {
     }
     do {
       // fetch subattribute
-      last = last.get(*begin);      
+      last = last.get(*begin);
       if (last.isExternal()) {
         last = last.resolveExternal();
-      }      
+      }
       // abort as early as possible
       if (last.isNone() || (++begin != end && !last.isObject())) {
         return Slice();
@@ -571,26 +574,26 @@ class Slice {
   // returns a Slice(ValueType::None) if not found
   template<typename T>
   typename std::enable_if<
-      std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<typename T::iterator>::iterator_category>::value, 
-      Slice>::type get(T const& attributes, 
+      std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<typename T::iterator>::iterator_category>::value,
+      Slice>::type get(T const& attributes,
                        bool resolveExternals = false) const {
     // forward to the iterator-based lookup
     return this->get(attributes.begin(), attributes.end(), resolveExternals);
   }
-  
+
   // look for the specified attribute path inside an Object
   // returns a Slice(ValueType::None) if not found
   template<typename T>
-  Slice get(std::initializer_list<T> const& attributes, 
+  Slice get(std::initializer_list<T> const& attributes,
             bool resolveExternals = false) const {
     // forward to the iterator-based lookup
     return this->get(attributes.begin(), attributes.end(), resolveExternals);
   }
-  
+
   // look for the specified attribute inside an Object
   // returns a Slice(ValueType::None) if not found
   Slice get(StringRef const& attribute) const;
-  
+
   Slice get(HashedStringRef const& attribute) const {
     return get(StringRef(attribute));
   }
@@ -610,7 +613,7 @@ class Slice {
   Slice get(char const* attribute, std::size_t length) const {
     return get(StringRef(attribute, length));
   }
-  
+
   Slice operator[](StringRef const& attribute) const {
     return get(attribute);
   }
@@ -618,26 +621,26 @@ class Slice {
   Slice operator[](std::string const& attribute) const {
     return get(attribute.data(), attribute.size());
   }
-  
+
   // whether or not an Object has a specific sub-key
   template<typename T>
   typename std::enable_if<
-      std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<typename T::iterator>::iterator_category>::value, 
+      std::is_base_of<std::forward_iterator_tag, typename std::iterator_traits<typename T::iterator>::iterator_category>::value,
       bool>::type hasKey(T const& attributes) const {
     return !this->get(attributes.begin(), attributes.end()).isNone();
   }
-  
+
   // whether or not an Object has a specific key
   template<typename T>
   bool hasKey(std::initializer_list<T> const& attributes) const {
     return !this->get(attributes.begin(), attributes.end()).isNone();
   }
-  
+
   // whether or not an Object has a specific key
   bool hasKey(StringRef const& attribute) const {
     return !get(attribute).isNone();
   }
-  
+
   // whether or not an Object has a specific key
   bool hasKey(HashedStringRef const& attribute) const {
     return hasKey(StringRef(attribute));
@@ -646,7 +649,7 @@ class Slice {
   bool hasKey(std::string const& attribute) const {
     return hasKey(StringRef(attribute));
   }
-  
+
   bool hasKey(char const* attribute) const {
 #if __cplusplus >= 201703
     return hasKey(StringRef(attribute, std::char_traits<char>::length(attribute)));
@@ -654,7 +657,7 @@ class Slice {
     return hasKey(StringRef(attribute, std::strlen(attribute)));
 #endif
   }
-  
+
   bool hasKey(char const* attribute, std::size_t length) const {
     return hasKey(StringRef(attribute, length));
   }
@@ -666,7 +669,7 @@ class Slice {
     }
     return extractPointer();
   }
-  
+
   // returns the Slice managed by an External or the Slice itself if it's not
   // an External
   Slice resolveExternal() const {
@@ -675,7 +678,7 @@ class Slice {
     }
     return *this;
   }
- 
+
   // returns the Slice managed by an External or the Slice itself if it's not
   // an External, recursive version
   Slice resolveExternals() const {
@@ -687,18 +690,18 @@ class Slice {
   }
 
   // tests whether the Slice is an empty array
-  bool isEmptyArray() const { 
+  bool isEmptyArray() const {
     return isArray() && length() == 0;
   }
 
   // tests whether the Slice is an empty object
-  bool isEmptyObject() const { 
+  bool isEmptyObject() const {
     return isObject() && length() == 0;
   }
 
   // translates an integer key into a string
   Slice translate() const;
- 
+
   // return the value for an Int object
   int64_t getInt() const;
 
@@ -707,7 +710,7 @@ class Slice {
 
   // return the value for a SmallInt object
   int64_t getSmallInt() const;
-  
+
   template <typename T>
   T getNumber() const {
     if (std::is_integral<T>()) {
@@ -796,7 +799,7 @@ class Slice {
 
     throw Exception(Exception::InvalidValueType, "Expecting type String");
   }
-  
+
   char const* getStringUnchecked(ValueLength& length) const noexcept {
     uint8_t const h = head();
     if (h >= 0x40 && h <= 0xbe) {
@@ -845,7 +848,7 @@ class Slice {
 
     throw Exception(Exception::InvalidValueType, "Expecting type String");
   }
-  
+
   // return a copy of the value for a String object
   StringRef stringRef() const {
     uint8_t h = head();
@@ -946,24 +949,24 @@ class Slice {
     }
     return 9;
   }
-  
+
   // get the offset for the nth member from an Array type
   ValueLength getNthOffset(ValueLength index) const;
 
   Slice makeKey() const;
 
   int compareString(StringRef const& value) const;
-  
+
   inline int compareString(std::string const& value) const {
     return compareString(StringRef(value.data(), value.size()));
   }
-  
+
   int compareString(char const* value, std::size_t length) const {
     return compareString(StringRef(value, length));
   }
-  
+
   int compareStringUnchecked(StringRef const& value) const noexcept;
-  
+
   int compareStringUnchecked(std::string const& value) const noexcept {
     return compareStringUnchecked(StringRef(value.data(), value.size()));
   }
@@ -971,13 +974,13 @@ class Slice {
   int compareStringUnchecked(char const* value, std::size_t length) const noexcept {
     return compareStringUnchecked(StringRef(value, length));
   }
-  
+
   bool isEqualString(StringRef const& attribute) const;
 
   bool isEqualString(std::string const& attribute) const {
     return isEqualString(StringRef(attribute.data(), attribute.size()));
   }
-  
+
   bool isEqualStringUnchecked(StringRef const& attribute) const noexcept;
 
   bool isEqualStringUnchecked(std::string const& attribute) const noexcept {
@@ -1007,11 +1010,11 @@ class Slice {
 
     return (std::memcmp(start(), other.start(), checkOverflow(size)) == 0);
   }
- 
+
   static bool binaryEquals(uint8_t const* left, uint8_t const* right) {
     return Slice(left).binaryEquals(Slice(right));
   }
-  
+
   // these operators are now deleted because they didn't do what people expected
   // these operators checked for _binary_ equality of the velocypack slice with
   // another. however, for several values there are multiple possible representations,
@@ -1025,7 +1028,7 @@ class Slice {
   std::string toJson(Options const* options = &Options::Defaults) const;
   std::string toString(Options const* options = &Options::Defaults) const;
   std::string hexType() const;
-  
+
   int64_t getIntUnchecked() const noexcept;
 
   // return the value for a UInt object, without checks
@@ -1052,7 +1055,39 @@ class Slice {
     return valueStart() + 1 + mlenlen + 4;
   }
 
+  template<typename... Ts>
+  std::tuple<Ts...> unpackTuple() const {
+    if (!isArray()) {
+      throw Exception(Exception::InvalidValueType, "Expecting type Array");
+    }
+    auto offset = getNthOffset(0);
+    auto length = arrayLength();
+    if (length < sizeof...(Ts)) {
+      throw Exception(Exception::IndexOutOfBounds);
+    }
+
+    return unpackTupleInternal(unpack_helper<Ts...>{}, offset);
+  }
+
+  template<typename T>
+  T extract() const {
+    return Extractor<T>::extract(*this);
+  }
+
  private:
+  template<typename...>
+  struct unpack_helper {};
+
+  template<typename T, typename... Ts>
+  std::tuple<T, Ts...> unpackTupleInternal(unpack_helper<T, Ts...>, std::size_t offset) const {
+    auto slice = Slice(this->_start + offset);
+    return std::tuple_cat(std::make_tuple(slice.extract<T>()), unpackTupleInternal(unpack_helper<Ts...>{}, offset + slice.byteSize()));
+  }
+
+  std::tuple<> unpackTupleInternal(unpack_helper<>, std::size_t) const {
+    return std::make_tuple<>();
+  }
+
   // get the type for the slice (including tags)
   static constexpr inline ValueType type(uint8_t h) {
     return SliceStaticData::TypeMap[h];
@@ -1096,7 +1131,7 @@ class Slice {
     ValueLength end = readIntegerNonEmpty<ValueLength>(start() + 1, offsetSize);
     return readIntegerNonEmpty<ValueLength>(start() + end - offsetSize, offsetSize);
   }
-  
+
   // return the number of members for an Object
   // must only be called for Slices that have been validated to be of type Object
   ValueLength objectLength() const {
@@ -1126,7 +1161,7 @@ class Slice {
   }
 
   // get the total byte size for a String slice, including the head byte.
-  // no check is done if the type of the slice is actually String 
+  // no check is done if the type of the slice is actually String
   ValueLength stringSliceLength() const noexcept {
     // check if the type has a fixed length first
     auto const h = head();
@@ -1137,7 +1172,7 @@ class Slice {
     }
     return static_cast<ValueLength>(1 + h - 0x40);
   }
-  
+
   // translates an integer key into a string, without checks
   Slice translateUnchecked() const;
 
@@ -1158,7 +1193,7 @@ class Slice {
 
   // get the offset for the nth member from a compact Array or Object type
   ValueLength getNthOffsetFromCompact(ValueLength index) const;
-  
+
   // get the offset for the first member from a compact Array or Object type
   // it is only valid to call this method for compact Array or Object values with
   // at least one member!!
@@ -1321,6 +1356,59 @@ class Slice {
 
 static_assert(!std::is_polymorphic<Slice>::value, "Slice must not be polymorphic");
 static_assert(!std::has_virtual_destructor<Slice>::value, "Slice must not have virtual dtor");
+
+template<typename T, typename>
+struct Extractor {
+  template<typename>
+  struct always_false : std::false_type {};
+  static_assert(always_false<T>::value, "There is no extractor for this type.");
+};
+
+
+template<>
+struct Extractor<Slice> {
+  static Slice extract(Slice slice) {
+    return slice;
+  }
+};
+
+template<>
+struct Extractor<std::string> {
+  static std::string extract(Slice slice) {
+    return slice.copyString();
+  }
+};
+
+template<>
+struct Extractor<StringRef> {
+  static StringRef extract(Slice slice) {
+    return slice.stringRef();
+  }
+};
+
+#if VELOCYPACK_HAS_STRING_VIEW
+template<>
+struct Extractor<std::string_view> {
+  static std::string_view extract(Slice slice) {
+    return slice.stringView();
+  }
+};
+#endif
+
+template<>
+struct Extractor<bool> {
+  static bool extract(Slice slice) {
+    return slice.getBool();
+  }
+};
+
+template<typename T>
+struct Extractor<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
+  static T extract(Slice slice) {
+    return slice.template getNumericValue<T>();
+  }
+};
+
 
 }  // namespace arangodb::velocypack
 }  // namespace arangodb

--- a/tests/testsIterator.cpp
+++ b/tests/testsIterator.cpp
@@ -88,7 +88,7 @@ TEST(IteratorTest, IterateArrayEmpty) {
 
   it.next();
   ASSERT_FALSE(it.valid());
-  
+
   ASSERT_VELOCYPACK_EXCEPTION((*it), Exception::IndexOutOfBounds);
 }
 
@@ -101,7 +101,7 @@ TEST(IteratorTest, IterateArrayEmptySpecial) {
 
   it.next();
   ASSERT_FALSE(it.valid());
-  
+
   ASSERT_VELOCYPACK_EXCEPTION((*it), Exception::IndexOutOfBounds);
 }
 
@@ -216,14 +216,14 @@ TEST(IteratorTest, IterateArrayForward) {
   current = it.value();
   ASSERT_TRUE(current.isBool());
   ASSERT_TRUE(current.getBool());
-  
+
   it.forward(2);
 
   ASSERT_TRUE(it.valid());
   current = it.value();
   ASSERT_TRUE(current.isString());
   ASSERT_EQ("bar", current.copyString());
-  
+
   it.forward(1);
 
   ASSERT_FALSE(it.valid());
@@ -235,7 +235,7 @@ TEST(IteratorTest, IterateArrayForward) {
 
 TEST(IteratorTest, IterateCompactArrayForward) {
   std::string const value("[1,2,3,4,null,true,\"foo\",\"bar\"]");
-  
+
   Options options;
   options.buildUnindexedArrays = true;
 
@@ -278,14 +278,14 @@ TEST(IteratorTest, IterateCompactArrayForward) {
   current = it.value();
   ASSERT_TRUE(current.isBool());
   ASSERT_TRUE(current.getBool());
-  
+
   it.forward(2);
 
   ASSERT_TRUE(it.valid());
   current = it.value();
   ASSERT_TRUE(current.isString());
   ASSERT_EQ("bar", current.copyString());
-  
+
   it.forward(1);
 
   ASSERT_FALSE(it.valid());
@@ -601,7 +601,7 @@ TEST(IteratorTest, IterateObjectUnsorted) {
   ASSERT_EQ(1UL, current.getUInt());
 
   it.next();
-  
+
   ASSERT_TRUE(it.valid());
   key = it.key();
   current = it.value();
@@ -610,7 +610,7 @@ TEST(IteratorTest, IterateObjectUnsorted) {
   ASSERT_EQ(2UL, current.getUInt());
 
   it.next();
-  
+
   ASSERT_TRUE(it.valid());
   key = it.key();
   current = it.value();
@@ -1213,6 +1213,27 @@ TEST(IteratorTest, ObjectIteratorToStream) {
     result << it;
     ASSERT_EQ("[ObjectIterator 4 / 3]", result.str());
   }
+}
+
+TEST(IteratorTest, ArrayIteratorUnpackTuple) {
+  Builder b;
+  b.openArray();
+  b.add(Value("some string"));
+  b.add(Value(12));
+  b.add(Value(false));
+  b.add(Value("extracted as slice"));
+  b.close();
+
+  Slice s = b.slice();
+  ArrayIterator iter(s);
+  auto t = iter.unpackTuple<std::string, int, bool>();
+
+  ASSERT_EQ(std::get<0>(t), "some string");
+  ASSERT_EQ(std::get<1>(t), 12);
+  ASSERT_EQ(std::get<2>(t), false);
+
+  ASSERT_TRUE(iter.valid());
+  ASSERT_TRUE(iter.value().isEqualString("extracted as slice"));
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/testsSlice.cpp
+++ b/tests/testsSlice.cpp
@@ -99,7 +99,7 @@ TEST(SliceTest, ResolveExternal) {
 
   ASSERT_TRUE(Slice::trueSlice().isTrue());
   ASSERT_TRUE(Slice::trueSlice().resolveExternal().isTrue());
-  
+
   ASSERT_TRUE(Slice::zeroSlice().isSmallInt());
   ASSERT_TRUE(Slice::zeroSlice().resolveExternal().isSmallInt());
 
@@ -114,31 +114,31 @@ TEST(SliceTest, ResolveExternal) {
 
   ASSERT_TRUE(Slice::maxKeySlice().isMaxKey());
   ASSERT_TRUE(Slice::maxKeySlice().resolveExternal().isMaxKey());
- 
+
   Builder builder;
   builder.openArray();
   builder.add(Value(1));
   builder.close();
-   
+
   LocalBuffer[0] = 0x1d;
   char const* p = builder.slice().startAs<char const>();
   memcpy(&LocalBuffer[1], &p, sizeof(char const*));
-  
+
   ASSERT_TRUE(Slice(&LocalBuffer[0]).isExternal());
   ASSERT_FALSE(Slice(&LocalBuffer[0]).isArray());
   ASSERT_TRUE(Slice(&LocalBuffer[0]).resolveExternal().isArray());
   ASSERT_TRUE(Slice(&LocalBuffer[0]).resolveExternal().at(0).isNumber());
-  
+
   Builder builder2;
   builder2.openObject();
   builder2.add("foo", Value(1));
   builder2.add("bar", Value("baz"));
   builder2.close();
-  
+
   LocalBuffer[0] = 0x1d;
   p = builder2.slice().startAs<char const>();
   memcpy(&LocalBuffer[1], &p, sizeof(char const*));
-  
+
   ASSERT_TRUE(Slice(&LocalBuffer[0]).isExternal());
   ASSERT_FALSE(Slice(&LocalBuffer[0]).isObject());
   ASSERT_TRUE(Slice(&LocalBuffer[0]).resolveExternal().isObject());
@@ -162,9 +162,9 @@ TEST(SliceTest, GetResolveExternal) {
   builder.openObject();
   builder.add("boo", Value(static_cast<void const*>(bs.start()), ValueType::External));
   builder.close();
-   
+
   Slice s = builder.slice();
-  
+
   ASSERT_FALSE(s.get(std::vector<std::string>{"boo"}).isExternal());
   ASSERT_FALSE(s.get(std::vector<std::string>{"boo"}, false).isExternal());
   ASSERT_FALSE(s.get(std::vector<std::string>{"boo"}, true).isExternal());
@@ -182,12 +182,12 @@ TEST(SliceTest, GetResolveExternalExternal) {
   builder.openObject();
   builder.add("boo", Value(static_cast<void const*>(bExternal.slice().start()), ValueType::External));
   builder.close();
-   
+
   Builder b;
   b.add(Value(static_cast<void const*>(builder.slice().start()), ValueType::External));
 
   Slice s = b.slice();
-  
+
   ASSERT_FALSE(s.get(std::vector<std::string>{"boo"}, true).isExternal());
   ASSERT_TRUE(s.get(std::vector<std::string>{"boo"}, true).isObject());
 }
@@ -228,7 +228,7 @@ TEST(SliceTest, GetOnNonObject) {
     ASSERT_VELOCYPACK_EXCEPTION(s.get(lookup.begin(), lookup.end()), Exception::InvalidValueType);
   }
 }
- 
+
 #if __cplusplus >= 201300
 TEST(SliceTest, GetOnNestedObject) {
   std::string const value("{\"foo\":{\"bar\":{\"baz\":3,\"bark\":4},\"qux\":5},\"poo\":6}");
@@ -247,48 +247,48 @@ TEST(SliceTest, GetOnNestedObject) {
     ASSERT_TRUE(s.get(lookup).isNone());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNone());
     lookup.pop_back();
-    
+
     lookup.emplace_back("bar"); // foo.bar
     ASSERT_TRUE(s.get(lookup).isObject());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isObject());
-    
+
     lookup.emplace_back("baz"); // foo.bar.baz
     ASSERT_TRUE(s.get(lookup).isNumber());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNumber());
     ASSERT_EQ(3, s.get(lookup).getInt());
     ASSERT_EQ(3, s.get(lookup.begin(), lookup.end()).getInt());
-    
+
     lookup.emplace_back("bat"); // foo.bar.baz.bat
     ASSERT_TRUE(s.get(lookup).isNone());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNone());
     lookup.pop_back(); // foo.bar.baz
     lookup.pop_back(); // foo.bar
-    
+
     lookup.emplace_back("bark"); // foo.bar.bark
     ASSERT_TRUE(s.get(lookup).isNumber());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNumber());
     ASSERT_EQ(4, s.get(lookup).getInt());
     ASSERT_EQ(4, s.get(lookup.begin(), lookup.end()).getInt());
-    
+
     lookup.emplace_back("bat"); // foo.bar.bark.bat
     ASSERT_TRUE(s.get(lookup).isNone());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNone());
     lookup.pop_back(); // foo.bar.bark
     lookup.pop_back(); // foo.bar
-    
+
     lookup.emplace_back("borg"); // foo.bar.borg
     ASSERT_TRUE(s.get(lookup).isNone());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNone());
     lookup.pop_back(); // foo.bar
     lookup.pop_back(); // foo
-    
+
     lookup.emplace_back("qux"); // foo.qux
     ASSERT_TRUE(s.get(lookup).isNumber());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNumber());
     ASSERT_EQ(5, s.get(lookup).getInt());
     ASSERT_EQ(5, s.get(lookup.begin(), lookup.end()).getInt());
     lookup.pop_back(); // foo
-    
+
     lookup.emplace_back("poo"); // foo.poo
     ASSERT_TRUE(s.get(lookup).isNone());
     ASSERT_TRUE(s.get(lookup.begin(), lookup.end()).isNone());
@@ -304,7 +304,7 @@ TEST(SliceTest, GetOnNestedObject) {
 
   runTest(std::vector<std::string>());
   runTest(std::vector<StringRef>());
-  
+
   {
     auto lookup = { "foo", "bar", "baz" };
     ASSERT_TRUE(s.get(lookup).isNumber());
@@ -312,7 +312,7 @@ TEST(SliceTest, GetOnNestedObject) {
     ASSERT_EQ(3, s.get(lookup).getInt());
     ASSERT_EQ(3, s.get(lookup.begin(), lookup.end()).getInt());
   }
-  
+
   {
     std::initializer_list<char const*> lookup = { "foo", "bar", "baz" };
     ASSERT_TRUE(s.get(lookup).isNumber());
@@ -338,7 +338,7 @@ TEST(SliceTest, GetWithIterator) {
     ASSERT_EQ(3, s.get(lookup).getInt());
     ASSERT_EQ(3, s.get(lookup.begin(), lookup.end()).getInt());
   }
-  
+
   {
     std::initializer_list<char const*> lookup = { "foo", "bar", "baz" };
     ASSERT_TRUE(s.get(lookup).isNumber());
@@ -346,7 +346,7 @@ TEST(SliceTest, GetWithIterator) {
     ASSERT_EQ(3, s.get(lookup).getInt());
     ASSERT_EQ(3, s.get(lookup.begin(), lookup.end()).getInt());
   }
-  
+
   {
     std::initializer_list<std::string> lookup = { "foo", "bar", "baz" };
     ASSERT_TRUE(s.get(lookup).isNumber());
@@ -354,7 +354,7 @@ TEST(SliceTest, GetWithIterator) {
     ASSERT_EQ(3, s.get(lookup).getInt());
     ASSERT_EQ(3, s.get(lookup.begin(), lookup.end()).getInt());
   }
-  
+
   {
     std::initializer_list<StringRef> lookup = {StringRef("foo"), StringRef("bar"), StringRef("baz") };
     ASSERT_TRUE(s.get(lookup).isNumber());
@@ -362,7 +362,7 @@ TEST(SliceTest, GetWithIterator) {
     ASSERT_EQ(3, s.get(lookup).getInt());
     ASSERT_EQ(3, s.get(lookup.begin(), lookup.end()).getInt());
   }
-  
+
   {
     std::initializer_list<HashedStringRef> lookup = {HashedStringRef("foo", 3), HashedStringRef("bar", 3), HashedStringRef("baz", 3) };
     ASSERT_TRUE(s.get(lookup).isNumber());
@@ -371,7 +371,7 @@ TEST(SliceTest, GetWithIterator) {
     ASSERT_EQ(3, s.get(lookup.begin(), lookup.end()).getInt());
   }
 }
-  
+
 TEST(SliceTest, SliceStart) {
   std::string const value("null");
 
@@ -1348,12 +1348,12 @@ TEST(SliceTest, StringLengths) {
     builder.add(Value(temp));
 
     Slice slice = builder.slice();
-  
+
     ASSERT_TRUE(slice.isString());
     ASSERT_EQ(ValueType::String, slice.type());
-    
+
     ASSERT_EQ(i, slice.getStringLength());
-    
+
     if (i <= 126) {
       ASSERT_EQ(i + 1, slice.byteSize());
     } else {
@@ -1447,8 +1447,8 @@ TEST(SliceTest, StringNullBytes) {
     ASSERT_EQ('4', s[5]);
     ASSERT_EQ('\0', s[6]);
     ASSERT_EQ('x', s[7]);
-  } 
-  
+  }
+
   {
     StringRef s(slice.stringRef());
     ASSERT_EQ(8ULL, s.size());
@@ -2219,28 +2219,28 @@ TEST(SliceTest, HashObject) {
 TEST(SliceTest, NormalizedHashDouble) {
   Builder b1;
   b1.openArray();
-  b1.add(Value(-1.0)); 
-  b1.add(Value(0)); 
-  b1.add(Value(1.0)); 
-  b1.add(Value(2.0)); 
-  b1.add(Value(3.0)); 
+  b1.add(Value(-1.0));
+  b1.add(Value(0));
+  b1.add(Value(1.0));
+  b1.add(Value(2.0));
+  b1.add(Value(3.0));
   b1.add(Value(42.0));
-  b1.add(Value(-42.0)); 
-  b1.add(Value(123456.0)); 
-  b1.add(Value(-123456.0)); 
+  b1.add(Value(-42.0));
+  b1.add(Value(123456.0));
+  b1.add(Value(-123456.0));
   b1.close();
-  
+
   Builder b2;
   b2.openArray();
   b2.add(Value(-1));
-  b2.add(Value(0)); 
-  b2.add(Value(1)); 
-  b2.add(Value(2)); 
-  b2.add(Value(3)); 
-  b2.add(Value(42)); 
-  b2.add(Value(-42)); 
+  b2.add(Value(0));
+  b2.add(Value(1));
+  b2.add(Value(2));
+  b2.add(Value(3));
+  b2.add(Value(42));
+  b2.add(Value(-42));
   b2.add(Value(123456));
-  b2.add(Value(-123456)); 
+  b2.add(Value(-123456));
   b2.close();
 
   // hash values differ, but normalized hash values shouldn't!
@@ -2253,15 +2253,15 @@ TEST(SliceTest, NormalizedHashDouble) {
 
 TEST(SliceTest, NormalizedHashArray) {
   Options options;
-  
+
   options.buildUnindexedArrays = false;
   std::shared_ptr<Builder> b1 = Parser::fromJson("[1,2,3,4,5,6,7,8,9,10]", &options);
   Slice s1 = b1->slice();
-  
+
   options.buildUnindexedArrays = true;
   std::shared_ptr<Builder> b2 = Parser::fromJson("[1,2,3,4,5,6,7,8,9,10]", &options);
   Slice s2 = b2->slice();
-  
+
   // hash values differ, but normalized hash values shouldn't!
   ASSERT_EQ(8308483934453544580ULL, s1.hash());
   ASSERT_EQ(15333913616940129336ULL, s2.hash());
@@ -2272,15 +2272,15 @@ TEST(SliceTest, NormalizedHashArray) {
 
 TEST(SliceTest, NormalizedHashArrayNested) {
   Options options;
-  
+
   options.buildUnindexedArrays = false;
   std::shared_ptr<Builder> b1 = Parser::fromJson("[-4.0,1,2.0,-4345.0,4,5,6,7,8,9,10,[1,9,-42,45.0]]", &options);
   Slice s1 = b1->slice();
-  
+
   options.buildUnindexedArrays = true;
   std::shared_ptr<Builder> b2 = Parser::fromJson("[-4.0,1,2.0,-4345.0,4,5,6,7,8,9,10,[1,9,-42,45.0]]", &options);
   Slice s2 = b2->slice();
-  
+
   // hash values differ, but normalized hash values shouldn't!
   ASSERT_EQ(15793061464938738924ULL, s1.hash());
   ASSERT_EQ(2722569323545975071ULL, s2.hash());
@@ -2297,12 +2297,12 @@ TEST(SliceTest, NormalizedHashObjectOrder) {
       "{\"one\":1,\"two\":2,\"three\":3,\"four\":4,\"five\":5,\"six\":6,"
       "\"seven\":7}", &options);
   Slice s1 = b1->slice();
-  
+
   options.buildUnindexedObjects = false;
   std::shared_ptr<Builder> b2 = Parser::fromJson(
       "{\"seven\":7,\"six\":6,\"five\":5,\"four\":4,\"three\":3,\"two\":2,\"one\":1}", &options);
   Slice s2 = b2->slice();
-  
+
   // hash values differ, but normalized hash values shouldn't!
   ASSERT_EQ(8873752126133306149ULL, s1.hash());
   ASSERT_EQ(9972002797221051811ULL, s2.hash());
@@ -2397,28 +2397,28 @@ TEST(SliceTest, HashObject) {
 TEST(SliceTest, NormalizedHashDouble) {
   Builder b1;
   b1.openArray();
-  b1.add(Value(-1.0)); 
-  b1.add(Value(0)); 
-  b1.add(Value(1.0)); 
-  b1.add(Value(2.0)); 
-  b1.add(Value(3.0)); 
+  b1.add(Value(-1.0));
+  b1.add(Value(0));
+  b1.add(Value(1.0));
+  b1.add(Value(2.0));
+  b1.add(Value(3.0));
   b1.add(Value(42.0));
-  b1.add(Value(-42.0)); 
-  b1.add(Value(123456.0)); 
-  b1.add(Value(-123456.0)); 
+  b1.add(Value(-42.0));
+  b1.add(Value(123456.0));
+  b1.add(Value(-123456.0));
   b1.close();
-  
+
   Builder b2;
   b2.openArray();
   b2.add(Value(-1));
-  b2.add(Value(0)); 
-  b2.add(Value(1)); 
-  b2.add(Value(2)); 
-  b2.add(Value(3)); 
-  b2.add(Value(42)); 
-  b2.add(Value(-42)); 
+  b2.add(Value(0));
+  b2.add(Value(1));
+  b2.add(Value(2));
+  b2.add(Value(3));
+  b2.add(Value(42));
+  b2.add(Value(-42));
   b2.add(Value(123456));
-  b2.add(Value(-123456)); 
+  b2.add(Value(-123456));
   b2.close();
 
   // hash values differ, but normalized hash values shouldn't!
@@ -2431,15 +2431,15 @@ TEST(SliceTest, NormalizedHashDouble) {
 
 TEST(SliceTest, NormalizedHashArray) {
   Options options;
-  
+
   options.buildUnindexedArrays = false;
   std::shared_ptr<Builder> b1 = Parser::fromJson("[1,2,3,4,5,6,7,8,9,10]", &options);
   Slice s1 = b1->slice();
-  
+
   options.buildUnindexedArrays = true;
   std::shared_ptr<Builder> b2 = Parser::fromJson("[1,2,3,4,5,6,7,8,9,10]", &options);
   Slice s2 = b2->slice();
-  
+
   // hash values differ, but normalized hash values shouldn't!
   ASSERT_EQ(1515761289406454211ULL, s1.hash());
   ASSERT_EQ(6179595527158943660ULL, s2.hash());
@@ -2450,15 +2450,15 @@ TEST(SliceTest, NormalizedHashArray) {
 
 TEST(SliceTest, NormalizedHashArrayNested) {
   Options options;
-  
+
   options.buildUnindexedArrays = false;
   std::shared_ptr<Builder> b1 = Parser::fromJson("[-4.0,1,2.0,-4345.0,4,5,6,7,8,9,10,[1,9,-42,45.0]]", &options);
   Slice s1 = b1->slice();
-  
+
   options.buildUnindexedArrays = true;
   std::shared_ptr<Builder> b2 = Parser::fromJson("[-4.0,1,2.0,-4345.0,4,5,6,7,8,9,10,[1,9,-42,45.0]]", &options);
   Slice s2 = b2->slice();
-  
+
   // hash values differ, but normalized hash values shouldn't!
   ASSERT_EQ(437707331568343016ULL, s1.hash());
   ASSERT_EQ(12530379609568313352ULL, s2.hash());
@@ -2475,13 +2475,13 @@ TEST(SliceTest, NormalizedHashObject) {
       "{\"one\":1,\"two\":2,\"three\":3,\"four\":4,\"five\":5,\"six\":6,"
       "\"seven\":7}", &options);
   Slice s1 = b1->slice();
-  
+
   options.buildUnindexedObjects = true;
   std::shared_ptr<Builder> b2 = Parser::fromJson(
       "{\"one\":1,\"two\":2,\"three\":3,\"four\":4,\"five\":5,\"six\":6,"
       "\"seven\":7}", &options);
   Slice s2 = b2->slice();
-  
+
   // hash values differ, but normalized hash values shouldn't!
 #ifdef VELOCYPACK_XXHASH
   ASSERT_EQ(15518419071972093120ULL, s1.hash());
@@ -2504,12 +2504,12 @@ TEST(SliceTest, NormalizedHashObjectOrder) {
       "{\"one\":1,\"two\":2,\"three\":3,\"four\":4,\"five\":5,\"six\":6,"
       "\"seven\":7}", &options);
   Slice s1 = b1->slice();
-  
+
   options.buildUnindexedObjects = false;
   std::shared_ptr<Builder> b2 = Parser::fromJson(
       "{\"seven\":7,\"six\":6,\"five\":5,\"four\":4,\"three\":3,\"two\":2,\"one\":1}", &options);
   Slice s2 = b2->slice();
-  
+
   // hash values differ, but normalized hash values shouldn't!
   ASSERT_EQ(6865527808070733846ULL, s1.hash());
   ASSERT_EQ(11084437118009261125ULL, s2.hash());
@@ -2693,18 +2693,18 @@ TEST(SliceTest, Translate) {
   Slice s = Slice(b.start());
 
   ASSERT_EQ(7UL, s.length());
-  
+
   ASSERT_EQ("bar", Slice(s.start() + s.getNthOffset(0)).translate().copyString());
   ASSERT_EQ("bark", Slice(s.start() + s.getNthOffset(1)).translate().copyString());
-  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(2)).translate().copyString(), Exception::InvalidValueType); 
+  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(2)).translate().copyString(), Exception::InvalidValueType);
   ASSERT_EQ("baz", Slice(s.start() + s.getNthOffset(3)).translate().copyString());
   ASSERT_EQ("foo", Slice(s.start() + s.getNthOffset(4)).translate().copyString());
   ASSERT_EQ("mötör", Slice(s.start() + s.getNthOffset(5)).translate().copyString());
-  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(6)).translate().copyString(), Exception::InvalidValueType); 
+  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(6)).translate().copyString(), Exception::InvalidValueType);
 
   // try again w/o AttributeTranslator
   scope.revert();
-  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(0)).translate().copyString(), Exception::NeedAttributeTranslator); 
+  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(0)).translate().copyString(), Exception::NeedAttributeTranslator);
 }
 
 TEST(SliceTest, TranslateSingleMember) {
@@ -2726,12 +2726,12 @@ TEST(SliceTest, TranslateSingleMember) {
   Slice s = Slice(b.start());
 
   ASSERT_EQ(1UL, s.length());
-  
+
   ASSERT_EQ("foo", Slice(s.start() + s.getNthOffset(0)).translate().copyString());
 
   // try again w/o AttributeTranslator
   scope.revert();
-  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(0)).translate().copyString(), Exception::NeedAttributeTranslator); 
+  ASSERT_VELOCYPACK_EXCEPTION(Slice(s.start() + s.getNthOffset(0)).translate().copyString(), Exception::NeedAttributeTranslator);
 }
 
 TEST(SliceTest, Translations) {
@@ -3121,7 +3121,7 @@ TEST(SliceTest, IsNumber) {
   ASSERT_EQ(int64_t(0), s.getNumber<int64_t>());
   ASSERT_EQ(uint64_t(0), s.getNumber<uint64_t>());
   ASSERT_EQ(double(0.0), s.getNumber<double>());
-  
+
   // positive int
   b.clear();
   b.add(Value(int(42)));
@@ -3137,8 +3137,8 @@ TEST(SliceTest, IsNumber) {
   ASSERT_EQ(int64_t(42), s.getNumber<int64_t>());
   ASSERT_EQ(uint64_t(42), s.getNumber<uint64_t>());
   ASSERT_EQ(double(42.0), s.getNumber<double>());
- 
-  
+
+
   // negative int
   b.clear();
   b.add(Value(int(-2)));
@@ -3154,8 +3154,8 @@ TEST(SliceTest, IsNumber) {
   ASSERT_EQ(int64_t(-2), s.getNumber<int64_t>());
   ASSERT_VELOCYPACK_EXCEPTION(s.getNumber<uint64_t>(), Exception::NumberOutOfRange);
   ASSERT_EQ(double(-2.0), s.getNumber<double>());
-  
-  
+
+
   // positive big int
   b.clear();
   b.add(Value(int64_t(INT64_MAX)));
@@ -3169,8 +3169,8 @@ TEST(SliceTest, IsNumber) {
   ASSERT_EQ(int64_t(INT64_MAX), s.getNumber<int64_t>());
   ASSERT_EQ(uint64_t(INT64_MAX), s.getNumber<uint64_t>());
   ASSERT_EQ(double(INT64_MAX), s.getNumber<double>());
-  
-  
+
+
   // negative big int
   b.clear();
   b.add(Value(int64_t(INT64_MIN)));
@@ -3184,8 +3184,8 @@ TEST(SliceTest, IsNumber) {
   ASSERT_EQ(int64_t(INT64_MIN), s.getNumber<int64_t>());
   ASSERT_VELOCYPACK_EXCEPTION(s.getNumber<uint64_t>(), Exception::NumberOutOfRange);
   ASSERT_EQ(double(INT64_MIN), s.getNumber<double>());
-  
-  
+
+
   // positive big uint
   b.clear();
   b.add(Value(uint64_t(UINT64_MAX)));
@@ -3195,11 +3195,11 @@ TEST(SliceTest, IsNumber) {
   ASSERT_FALSE(s.isNumber<int64_t>());
   ASSERT_TRUE(s.isNumber<uint64_t>());
   ASSERT_TRUE(s.isNumber<double>());
-  
+
   ASSERT_VELOCYPACK_EXCEPTION(s.getNumber<int64_t>(), Exception::NumberOutOfRange);
   ASSERT_EQ(uint64_t(UINT64_MAX), s.getNumber<uint64_t>());
   ASSERT_EQ(double(UINT64_MAX), s.getNumber<double>());
-  
+
 
   // negative double
   b.clear();
@@ -3210,7 +3210,7 @@ TEST(SliceTest, IsNumber) {
   ASSERT_TRUE(s.isNumber<int64_t>());
   ASSERT_VELOCYPACK_EXCEPTION(s.getNumber<uint64_t>(), Exception::NumberOutOfRange);
   ASSERT_TRUE(s.isNumber<double>());
-  
+
 
   // positive double
   b.clear();
@@ -3291,6 +3291,24 @@ TEST(SliceTest, ReadTags8Bytes) {
   ASSERT_FALSE(s.hasTag(50));
 
   ASSERT_EQ(s.value().getInt(), 5);
+}
+
+TEST(SliceTest, UnpackTupleSlice) {
+  Builder b;
+  b.openArray();
+  b.add(Value("some string"));
+  b.add(Value(12));
+  b.add(Value(false));
+  b.add(Value("extracted as slice"));
+  b.close();
+
+  Slice s = b.slice();
+  auto t = s.unpackTuple<std::string, int, bool, Slice>();
+
+  ASSERT_EQ(std::get<0>(t), "some string");
+  ASSERT_EQ(std::get<1>(t), 12);
+  ASSERT_EQ(std::get<2>(t), false);
+  ASSERT_TRUE(std::get<3>(t).isString());
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
This adds a new function `unpackTuple<T_1, T_2, ..., T_n>` to `Slice` and `ArrayIterator`. It can be used to unpack values from an array given their types. Given a type a `Extractor<T>` is used to extract the type from a slice. Thus we can easily add more types and even user code can provide specializations for their types to extract them.

`unpackTuple` extracts the first `n` elements from a `Slice` and reads `n` elements from an `ArrayIterator`.

```
auto t = s.unpackTuple<std::string, int, bool, Slice>();
static_assert(std::is_same_v<decltype(t), std::tuple<std::string, int, bool, Slice>>);
```

Supported types are:

- `std::string`
- arithmetic types (`std::is_artihmetic`)
- `bool`
- `StringRef`
- `Slice`
- `std::string_view` (c++17 only)

As by-product it also adds `extract<T>` to slice.