### PR TITLE
UnpackTuple modifications

### DIFF
--- a/include/velocypack/Exception.h
+++ b/include/velocypack/Exception.h
@@ -53,6 +53,7 @@ class Exception : public virtual std::exception {
     NeedAttributeTranslator = 20,
     CannotTranslateKey = 21,
     KeyNotFound = 22, // not used anymore
+    BadTupleSize = 23,
 
     BuilderNotSealed = 30,
     BuilderNeedOpenObject = 31,

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -159,7 +159,7 @@ class ArrayIterator : public std::iterator<std::forward_iterator_tag, Slice> {
   }
 
   template<typename... Ts>
-  std::tuple<Ts...> unpackTuple() {
+  std::tuple<Ts...> unpackPrefixAsTuple() {
     return unpackTupleInternal(unpack_helper<Ts...>{});
   }
 

--- a/include/velocypack/Slice.h
+++ b/include/velocypack/Slice.h
@@ -1416,7 +1416,7 @@ struct Extractor<T, typename std::enable_if<std::is_arithmetic<T>::value>::type>
 template<typename... Ts>
 struct Extractor<std::tuple<Ts...>> {
   static std::tuple<Ts...> extract(Slice slice) {
-    return slice.unpackTuple<Ts...>(slice);
+    return slice.unpackTuple<Ts...>();
   }
 };
 

--- a/include/velocypack/Slice.h
+++ b/include/velocypack/Slice.h
@@ -1066,8 +1066,8 @@ class Slice {
     }
     auto offset = getNthOffset(0);
     auto length = arrayLength();
-    if (length < sizeof...(Ts)) {
-      throw Exception(Exception::IndexOutOfBounds);
+    if (length != sizeof...(Ts)) {
+      throw Exception(Exception::BadTupleSize);
     }
 
     return unpackTupleInternal(unpack_helper<Ts...>{}, offset);
@@ -1410,6 +1410,13 @@ template<typename T>
 struct Extractor<T, typename std::enable_if<std::is_arithmetic<T>::value>::type> {
   static T extract(Slice slice) {
     return slice.template getNumericValue<T>();
+  }
+};
+
+template<typename... Ts>
+struct Extractor<std::tuple<Ts...>> {
+  static std::tuple<Ts...> extract(Slice slice) {
+    return slice.unpackTuple<Ts...>(slice);
   }
 };
 

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -64,6 +64,8 @@ char const* Exception::message(ExceptionType type) noexcept {
       return "Cannot translate key";
     case KeyNotFound:
       return "Key not found";
+    case BadTupleSize:
+      return "Array size does not match tuple size";
     case BuilderNotSealed:
       return "Builder value not yet sealed";
     case BuilderNeedOpenObject:

--- a/tests/testsException.cpp
+++ b/tests/testsException.cpp
@@ -80,6 +80,8 @@ TEST(ExceptionTest, TestMessages) {
                Exception::message(Exception::ValidatorInvalidType));
   ASSERT_STREQ("Invalid length found in binary data",
                Exception::message(Exception::ValidatorInvalidLength));
+  ASSERT_STREQ("Array size does not match tuple size",
+               Exception::message(Exception::BadTupleSize));
 
   ASSERT_STREQ("Unknown error", Exception::message(Exception::UnknownError));
   ASSERT_STREQ("Unknown error",

--- a/tests/testsIterator.cpp
+++ b/tests/testsIterator.cpp
@@ -1226,7 +1226,7 @@ TEST(IteratorTest, ArrayIteratorUnpackTuple) {
 
   Slice s = b.slice();
   ArrayIterator iter(s);
-  auto t = iter.unpackTuple<std::string, int, bool>();
+  auto t = iter.unpackPrefixAsTuple<std::string, int, bool>();
 
   ASSERT_EQ(std::get<0>(t), "some string");
   ASSERT_EQ(std::get<1>(t), 12);

--- a/tests/testsSlice.cpp
+++ b/tests/testsSlice.cpp
@@ -3399,6 +3399,24 @@ TEST(SliceTest, UnpackTupleSlice) {
   ASSERT_TRUE(std::get<3>(t).isString());
 }
 
+TEST(SliceTest, ExtractTuple) {
+  Builder b;
+  b.openArray();
+  b.add(Value("some string"));
+  b.add(Value(12));
+  b.add(Value(false));
+  b.add(Value("extracted as slice"));
+  b.close();
+
+  Slice s = b.slice();
+  auto t = s.extract<std::tuple<std::string, int, bool, Slice>>();
+
+  ASSERT_EQ(std::get<0>(t), "some string");
+  ASSERT_EQ(std::get<1>(t), 12);
+  ASSERT_EQ(std::get<2>(t), false);
+  ASSERT_TRUE(std::get<3>(t).isString());
+}
+
 int main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/tests/testsSlice.cpp
+++ b/tests/testsSlice.cpp
@@ -3399,6 +3399,18 @@ TEST(SliceTest, UnpackTupleSlice) {
   ASSERT_TRUE(std::get<3>(t).isString());
 }
 
+TEST(SliceTest, UnpackTupleSliceInvalidSize) {
+  Builder b;
+  b.openArray();
+  b.add(Value("some string"));
+  b.add(Value(12));
+  b.add(Value(false));
+  b.close();
+
+  Slice s = b.slice();
+  ASSERT_VELOCYPACK_EXCEPTION((s.unpackTuple<std::string, int, bool, Slice>()), Exception::BadTupleSize)
+}
+
 TEST(SliceTest, ExtractTuple) {
   Builder b;
   b.openArray();


### PR DESCRIPTION
This is a small modification to the `unpackTuple` API. When using `unpackTuple` on a slice, the underlying array is expected to have exactly the length of the tuple. Otherwise the new error code `BadTupleSize` is thrown. For `ArrayIterators` the function was renamed to `unpackPrefixAsTuple` to indicate that it behaves differently. This function will forward the iterator and read the given number of elements and does not expect the iterator to be at the end position after everything was read. If you want to extract a prefix from a slice use `ArrayIterator(slice).unpackPrefixAsTuple<...>()` instead.

To allow unpacking of nested tuples, e.g. `slice.unpack<int, std::tuple<int, int>, std::string>()` an `Extractor` for tuples was added.