### PR TITLE
fix an overly pessimistic size calculation

### DIFF
--- a/include/velocypack/Builder.h
+++ b/include/velocypack/Builder.h
@@ -193,7 +193,7 @@ class Builder {
 
     // Reserves len bytes at pos of the current state (top of stack)
     // or throws an exception
-    if (_pos + len < _bufferPtr->size()) {
+    if (_pos + len < _bufferPtr->capacity()) {
       return;  // All OK, we can just increase tos->pos by len
     }
 


### PR DESCRIPTION
Fix an overly pessimistic size calculation in `Builder::reserve()`.
This compared the Buffer's current size with the desired target size, but it should rather have compared with the Buffer's capacity.
The change rectifies that, so we can avoid unnecessary calls into `Buffer::reserve()` now, which would have returned from the call anyway in case enough Buffer capacity was still available to satisfy the reserve request.