### PR TITLE
fixed issue #109

### DIFF
--- a/src/Validator.cpp
+++ b/src/Validator.cpp
@@ -259,11 +259,14 @@ void Validator::validateCompactArray(uint8_t const* ptr, std::size_t length) {
     throw Exception(Exception::ValidatorInvalidLength, "Array length value is out of bounds");
   }
   ++p;
-
+  
   // validate the array members
   uint8_t const* e = p;
   p = data;
   while (nrItems-- > 0) {
+    if (p >= e) {
+      throw Exception(Exception::ValidatorInvalidLength, "Array items number is out of bounds");
+    }
     validate(p, e - p, true);
     p += Slice(p).byteSize();
   }

--- a/tests/testsValidator.cpp
+++ b/tests/testsValidator.cpp
@@ -1830,6 +1830,34 @@ TEST(ValidatorTest, ArrayCompactNrItemsWrong3) {
   ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
 }
 
+TEST(ValidatorTest, ArrayCompactNrItemsExceedsBytesize) {
+  std::string const value("\x13\x06\x42\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
+TEST(ValidatorTest, ArrayCompactMemberExceedsBytesize1) {
+  std::string const value("\x13\x06\x43\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
+TEST(ValidatorTest, ArrayCompactMemberExceedsBytesize2) {
+  std::string const value("\x13\x06\x44\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
+TEST(ValidatorTest, ArrayCompactMemberExceedsBytesize3) {
+  std::string const value("\x13\x06\x45\x40\x40\x02", 6);
+
+  Validator validator;
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
+}
+
 TEST(ValidatorTest, ArrayCompactManyEntries) {
   Builder b;
   b.openArray(true);


### PR DESCRIPTION
Bug fix for the issue reported in https://github.com/arangodb/velocypack/issues/109.
There was a loophole in the validation of compact arrays. The specified number of array members was used to iterate over the array member memory without checking if this would read over the bounds.
