### PR TITLE
add nestingLimit for Options

### DIFF
--- a/include/velocypack/Exception.h
+++ b/include/velocypack/Exception.h
@@ -52,6 +52,7 @@ class Exception : public virtual std::exception {
     CannotTranslateKey = 21,
     KeyNotFound = 22, // not used anymore
     BadTupleSize = 23,
+    TooDeepNesting = 24,
 
     BuilderNotSealed = 30,
     BuilderNeedOpenObject = 31,

--- a/include/velocypack/Options.h
+++ b/include/velocypack/Options.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <limits>
 #include <string>
 
 #include "velocypack/velocypack-common.h"
@@ -100,7 +102,8 @@ struct Options {
   // clear builder before starting to parse in Parser
   bool clearBuilderBeforeParse = true;
 
-  // validate UTF-8 strings when JSON-parsing with Parser
+  // validate UTF-8 strings when JSON-parsing with Parser or validating with 
+  // Validator
   bool validateUtf8Strings = false;
 
   // validate that attribute names in Object values are actually
@@ -146,6 +149,10 @@ struct Options {
 
   // write tags to JSON output
   bool debugTags = false;
+
+  // max recursion level for object/array nesting. checked by Parser and 
+  // Validator.
+  uint32_t nestingLimit = std::numeric_limits<uint32_t>::max(); 
 
   // default options with the above settings
   static Options Defaults;

--- a/include/velocypack/Parser.h
+++ b/include/velocypack/Parser.h
@@ -78,7 +78,7 @@ class Parser {
   uint8_t const* _start;
   std::size_t _size;
   std::size_t _pos;
-  int _nesting;
+  uint32_t _nesting;
 
  public:
   Options const* options;
@@ -135,7 +135,7 @@ class Parser {
         _size(0), 
         _pos(0), 
         _nesting(0),
-         options(options) {
+        options(options) {
     if (VELOCYPACK_UNLIKELY(options == nullptr)) {
       throw Exception(Exception::InternalError, "Options cannot be a nullptr");
     }
@@ -182,6 +182,7 @@ class Parser {
     _start = start;
     _size = size;
     _pos = 0;
+    _nesting = 0;
     if (options->clearBuilderBeforeParse) {
       _builder->clear();
     }
@@ -302,9 +303,9 @@ class Parser {
     return i;
   }
 
-  inline void increaseNesting() { ++_nesting; }
+  void increaseNesting(); 
 
-  inline void decreaseNesting() { --_nesting; }
+  void decreaseNesting() noexcept; 
 
   void parseNumber();
 

--- a/include/velocypack/Validator.h
+++ b/include/velocypack/Validator.h
@@ -27,6 +27,8 @@
 #include "velocypack/velocypack-common.h"
 #include "velocypack/Options.h"
 
+#include <cstdint>
+
 namespace arangodb::velocypack {
 class Slice;
 
@@ -37,7 +39,6 @@ class Validator {
   explicit Validator(Options const* options = &Options::Defaults);
   ~Validator() = default;
 
- public:
   // validates a VelocyPack Slice value starting at ptr, with length bytes length
   // throws if the data is invalid
   bool validate(char const* ptr, std::size_t length, bool isSubPart = false) {
@@ -47,8 +48,10 @@ class Validator {
   // validates a VelocyPack Slice value starting at ptr, with length bytes length
   // throws if the data is invalid
   bool validate(uint8_t const* ptr, std::size_t length, bool isSubPart = false);
-
+  
  private:
+  bool validatePart(uint8_t const* ptr, std::size_t length, bool isSubPart);
+
   void validateArray(uint8_t const* ptr, std::size_t length);
   void validateCompactArray(uint8_t const* ptr, std::size_t length);
   void validateUnindexedArray(uint8_t const* ptr, std::size_t length);
@@ -64,7 +67,7 @@ class Validator {
   Options const* options;
 
  private:
-  int _level;
+  uint32_t _level;
 };
 
 }  // namespace arangodb::velocypack

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -66,6 +66,8 @@ char const* Exception::message(ExceptionType type) noexcept {
       return "Key not found";
     case BadTupleSize:
       return "Array size does not match tuple size";
+    case TooDeepNesting:
+      return "Too deep nesting in Array/Object";
     case BuilderNotSealed:
       return "Builder value not yet sealed";
     case BuilderNeedOpenObject:

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -117,6 +117,17 @@ int Parser::skipWhiteSpace(char const* err) {
   } while (_pos < _size);
   throw Exception(Exception::ParseError, err);
 }
+  
+void Parser::increaseNesting() { 
+  if (++_nesting >= options->nestingLimit) {
+    throw Exception(Exception::TooDeepNesting);
+  }
+}
+
+void Parser::decreaseNesting() noexcept { 
+  VELOCYPACK_ASSERT(_nesting > 0);
+  --_nesting; 
+}
 
 // parses a number value
 void Parser::parseNumber() {
@@ -417,16 +428,17 @@ void Parser::parseString() {
 
 void Parser::parseArray() {
   _builderPtr->addArray();
+  
+  increaseNesting();
 
   int i = skipWhiteSpace("Expecting item or ']'");
   if (i == ']') {
     // empty array
     ++_pos;  // the closing ']'
+    decreaseNesting();
     _builderPtr->close();
     return;
   }
-
-  increaseNesting();
 
   while (true) {
     // parse array element itself
@@ -454,6 +466,7 @@ void Parser::parseArray() {
 void Parser::parseObject() {
   _builderPtr->addObject();
 
+  increaseNesting();
   int i = skipWhiteSpace("Expecting item or '}'");
   if (i == '}') {
     // empty object
@@ -461,12 +474,11 @@ void Parser::parseObject() {
 
     if (_nesting != 0 || !options->keepTopLevelOpen) {
       // only close if we've not been asked to keep top level open
+      decreaseNesting();
       _builderPtr->close();
     }
     return;
   }
-
-  increaseNesting();
 
   while (true) {
     // always expecting a string attribute name here

--- a/src/Slice.cpp
+++ b/src/Slice.cpp
@@ -132,6 +132,10 @@ std::string Slice::toJson(Options const* options) const {
 }
 
 std::string& Slice::toJson(std::string& out, Options const* options) const {
+  // reserve some initial space in the output string to avoid
+  // later reallocations. we use the Slice's byteSize as a first
+  // approximation for the needed output buffer size.
+  out.reserve(out.size() + byteSize());
   StringSink sink(&out);
   toJson(&sink, options);
   return out;
@@ -152,6 +156,11 @@ std::string Slice::toString(Options const* options) const {
   prettyOptions.prettyPrint = true;
 
   std::string buffer;
+  // reserve some initial space in the output string to avoid
+  // later reallocations. we use the Slice's byteSize as a first
+  // approximation for the needed output buffer size.
+  buffer.reserve(buffer.size() + byteSize());
+
   StringSink sink(&buffer);
   Dumper::dump(this, &sink, &prettyOptions);
   return buffer;

--- a/src/Validator.cpp
+++ b/src/Validator.cpp
@@ -67,10 +67,16 @@ Validator::Validator(Options const* options)
 }
 
 bool Validator::validate(uint8_t const* ptr, std::size_t length, bool isSubPart) {
+  // reset internal state
+  _level = 0;
+  return validatePart(ptr, length, isSubPart);
+}
+
+bool Validator::validatePart(uint8_t const* ptr, std::size_t length, bool isSubPart) {
   if (length == 0) {
     throw Exception(Exception::ValidatorInvalidLength, "length 0 is invalid for any VelocyPack value");
   }
-
+  
   uint8_t head = *ptr;
 
   // type() only reads the first byte, which is safe
@@ -122,14 +128,18 @@ bool Validator::validate(uint8_t const* ptr, std::size_t length, bool isSubPart)
     }
 
     case ValueType::Array: {
-      ++_level;
+      if (++_level >= options->nestingLimit) {
+        throw Exception(Exception::TooDeepNesting);
+      }
       validateArray(ptr, length);
       --_level;
       break;
     }
 
     case ValueType::Object: {
-      ++_level;
+      if (++_level >= options->nestingLimit) {
+        throw Exception(Exception::TooDeepNesting);
+      }
       validateObject(ptr, length);
       --_level;
       break;
@@ -272,7 +282,7 @@ void Validator::validateCompactArray(uint8_t const* ptr, std::size_t length) {
     if (p >= e) {
       throw Exception(Exception::ValidatorInvalidLength, "Array items number is out of bounds");
     }
-    validate(p, e - p, true);
+    validatePart(p, e - p, true);
     p += Slice(p).byteSize();
   }
 }
@@ -309,7 +319,7 @@ void Validator::validateUnindexedArray(uint8_t const* ptr, std::size_t length) {
     throw Exception(Exception::ValidatorInvalidLength, "Array padding is invalid");
   }
   
-  validate(p, length - (p - ptr), true);
+  validatePart(p, length - (p - ptr), true);
   ValueLength itemSize = Slice(p).byteSize();
   if (itemSize == 0) {
     throw Exception(Exception::ValidatorInvalidLength, "Array itemSize value is invalid");
@@ -329,7 +339,7 @@ void Validator::validateUnindexedArray(uint8_t const* ptr, std::size_t length) {
       throw Exception(Exception::ValidatorInvalidLength, "Array value is out of bounds");
     }
     // validate sub value
-    validate(p, e - p, true);
+    validatePart(p, e - p, true);
     if (Slice(p).byteSize() != itemSize) {
       // got a sub-object with a different size. this is not allowed
       throw Exception(Exception::ValidatorInvalidLength, "Unexpected Array value length");
@@ -405,7 +415,7 @@ void Validator::validateIndexedArray(uint8_t const* ptr, std::size_t length) {
   ValueLength actualNrItems = 0;
   uint8_t const* member = firstMember;
   while (member < indexTable) {
-    validate(member, indexTable - member, true);
+    validatePart(member, indexTable - member, true);
     ValueLength offset = readIntegerNonEmpty<ValueLength>(
         indexTable + actualNrItems * byteSizeLength, byteSizeLength);
     if (offset != static_cast<ValueLength>(member - ptr)) {
@@ -463,7 +473,7 @@ void Validator::validateCompactObject(uint8_t const* ptr, std::size_t length) {
       throw Exception(Exception::ValidatorInvalidLength, "Object items number is out of bounds");
     }
     // validate key
-    validate(p, e - p, true);
+    validatePart(p, e - p, true);
     Slice key(p);
     bool isString = key.isString();
     if (!isString) {
@@ -475,12 +485,12 @@ void Validator::validateCompactObject(uint8_t const* ptr, std::size_t length) {
     ValueLength keySize = key.byteSize();
     // validate key
     if (isString && options->validateUtf8Strings) {
-      validate(p, keySize, true);
+      validatePart(p, keySize, true);
     }
 
     // validate value
     p += keySize;
-    validate(p, e - p, true);
+    validatePart(p, e - p, true);
     p += Slice(p).byteSize();
   }
 
@@ -575,7 +585,7 @@ void Validator::validateIndexedObject(uint8_t const* ptr, std::size_t length) {
   ValueLength actualNrItems = 0;
   uint8_t const* member = firstMember;
   while (member < indexTable) {
-    validate(member, indexTable - member, true);
+    validatePart(member, indexTable - member, true);
 
     Slice key(member);
     bool const isString = key.isString();
@@ -588,14 +598,14 @@ void Validator::validateIndexedObject(uint8_t const* ptr, std::size_t length) {
 
     ValueLength const keySize = key.byteSize();
     if (isString && options->validateUtf8Strings) {
-      validate(member, keySize, true);
+      validatePart(member, keySize, true);
     }
 
     uint8_t const* value = member + keySize;
     if (value >= indexTable) {
       throw Exception(Exception::ValidatorInvalidLength, "Object value leaking into index table");
     }
-    validate(value, indexTable - value, true);
+    validatePart(value, indexTable - value, true);
 
     ValueLength offset = static_cast<ValueLength>(member - ptr);
     if (nrItems <= 128) {

--- a/tests/testsException.cpp
+++ b/tests/testsException.cpp
@@ -54,6 +54,10 @@ TEST(ExceptionTest, TestMessages) {
   ASSERT_STREQ("Cannot translate key",
                Exception::message(Exception::CannotTranslateKey));
   ASSERT_STREQ("Key not found", Exception::message(Exception::KeyNotFound));
+  ASSERT_STREQ("Array size does not match tuple size",
+               Exception::message(Exception::BadTupleSize));
+  ASSERT_STREQ("Too deep nesting in Array/Object",
+               Exception::message(Exception::TooDeepNesting));
   ASSERT_STREQ("Builder value not yet sealed",
                Exception::message(Exception::BuilderNotSealed));
   ASSERT_STREQ("Need open Object",
@@ -80,8 +84,6 @@ TEST(ExceptionTest, TestMessages) {
                Exception::message(Exception::ValidatorInvalidType));
   ASSERT_STREQ("Invalid length found in binary data",
                Exception::message(Exception::ValidatorInvalidLength));
-  ASSERT_STREQ("Array size does not match tuple size",
-               Exception::message(Exception::BadTupleSize));
 
   ASSERT_STREQ("Unknown error", Exception::message(Exception::UnknownError));
   ASSERT_STREQ("Unknown error",

--- a/tests/testsParser.cpp
+++ b/tests/testsParser.cpp
@@ -1508,6 +1508,48 @@ TEST(ParserTest, NestedArrayInvalid3) {
   ASSERT_EQ(34U, parser.errorPos());
 }
 
+TEST(ParserTest, ArrayNestingCloseToLimit1) {
+  Options options;
+  options.nestingLimit = 6;
+
+  std::string const value("[[[[[]]]]]");
+
+  Parser parser(&options);
+  ValueLength len = parser.parse(value);
+  ASSERT_EQ(1ULL, len);
+}
+
+TEST(ParserTest, ArrayNestingCloseToLimit2) {
+  Options options;
+  options.nestingLimit = 6;
+
+  std::string const value("[1, [2, [3, [4, [5] ] ] ] ]");
+
+  Parser parser(&options);
+  ValueLength len = parser.parse(value);
+  ASSERT_EQ(1ULL, len);
+}
+
+TEST(ParserTest, ArrayNestingBeyondLimit1) {
+  Options options;
+  options.nestingLimit = 5;
+
+  std::string const value("[[[[[[]]]]]]");
+
+  Parser parser(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value), Exception::TooDeepNesting);
+}
+
+TEST(ParserTest, ArrayNestingBeyondLimit2) {
+  Options options;
+  options.nestingLimit = 5;
+
+  std::string const value("[1, [2, [3, [4, [5, [6] ] ] ] ] ]");
+
+  Parser parser(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value), Exception::TooDeepNesting);
+}
+
 TEST(ParserTest, BrokenArray1) {
   std::string const value("[");
 
@@ -2310,6 +2352,48 @@ TEST(ParserTest, NoDuplicateAttributesUnsortedObjects) {
     Parser parser(&options);
     ASSERT_TRUE(parser.parse(value) > 0);
   }
+}
+
+TEST(ParserTest, ObjectNestingCloseToLimit1) {
+  Options options;
+  options.nestingLimit = 6;
+
+  std::string const value("{\"a\":{\"b\":{\"c\":{\"d\":{}}}}}");
+
+  Parser parser(&options);
+  ValueLength len = parser.parse(value);
+  ASSERT_EQ(1ULL, len);
+}
+
+TEST(ParserTest, ObjectNestingCloseToLimit2) {
+  Options options;
+  options.nestingLimit = 6;
+
+  std::string const value("{ \"a\": { \"b\": { \"c\": { \"d\": { } } } } }");
+
+  Parser parser(&options);
+  ValueLength len = parser.parse(value);
+  ASSERT_EQ(1ULL, len);
+}
+
+TEST(ParserTest, ObjectNestingBeyondLimit1) {
+  Options options;
+  options.nestingLimit = 5;
+
+  std::string const value("{\"a\":{\"b\":{\"c\":{\"d\":{\"e\":{}}}}}}");
+
+  Parser parser(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value), Exception::TooDeepNesting);
+}
+
+TEST(ParserTest, ObjectNestingBeyondLimit2) {
+  Options options;
+  options.nestingLimit = 5;
+
+  std::string const value("{ \"a\": { \"b\": { \"c\": { \"d\": { \"e\": { } } } } } }");
+
+  Parser parser(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(parser.parse(value), Exception::TooDeepNesting);
 }
 
 TEST(ParserTest, FromJsonString) {

--- a/tests/testsValidator.cpp
+++ b/tests/testsValidator.cpp
@@ -1935,6 +1935,66 @@ TEST(ValidatorTest, ArrayMoreItemsThanIndex) {
   ASSERT_VELOCYPACK_EXCEPTION(validator.validate(value.c_str(), value.size()), Exception::ValidatorInvalidLength);
 }
 
+TEST(ValidatorTest, ArrayNestingCloseToLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openArray();
+  }
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 6;
+
+  Validator validator(&options);
+  ASSERT_TRUE(validator.validate(b.slice().start(), b.slice().byteSize()));
+}
+
+TEST(ValidatorTest, CompactArrayNestingCloseToLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openArray(true);
+  }
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 6;
+
+  Validator validator(&options);
+  ASSERT_TRUE(validator.validate(b.slice().start(), b.slice().byteSize()));
+}
+
+TEST(ValidatorTest, ArrayNestingBeyondLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openArray();
+  }
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 5;
+
+  Validator validator(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(b.slice().start(), b.slice().byteSize()), Exception::TooDeepNesting);
+}
+
+TEST(ValidatorTest, CompactArrayNestingBeyondLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openArray(true);
+  }
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 5;
+
+  Validator validator(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(b.slice().start(), b.slice().byteSize()), Exception::TooDeepNesting);
+}
+
 TEST(ValidatorTest, ObjectMoreItemsThanIndex) {
   std::string const value("\x0B\x08\x01\xBE\x41\x61\x31\x04", 8);
 
@@ -2406,6 +2466,74 @@ TEST(ValidatorTest, ObjectFourByteManyEntries) {
 
   Validator validator;
   ASSERT_TRUE(validator.validate(b.slice().start(), b.slice().byteSize()));
+}
+
+TEST(ValidatorTest, ObjectNestingCloseToLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openObject();
+    b.add(Value("key"));
+  }
+  b.add(Value(true));
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 6;
+
+  Validator validator(&options);
+  ASSERT_TRUE(validator.validate(b.slice().start(), b.slice().byteSize()));
+}
+
+TEST(ValidatorTest, CompactObjectNestingCloseToLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openObject(true);
+    b.add(Value("key"));
+  }
+  b.add(Value(true));
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 6;
+
+  Validator validator(&options);
+  ASSERT_TRUE(validator.validate(b.slice().start(), b.slice().byteSize()));
+}
+
+TEST(ValidatorTest, ObjectNestingBeyondLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openObject(true);
+    b.add(Value("key"));
+  }
+  b.add(Value(true));
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 5;
+
+  Validator validator(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(b.slice().start(), b.slice().byteSize()), Exception::TooDeepNesting);
+}
+
+TEST(ValidatorTest, CompactObjectNestingBeyondLimit) {
+  Builder b;
+  for (int i = 0; i < 5; ++i) {
+    b.openObject(true);
+    b.add(Value("key"));
+  }
+  b.add(Value(true));
+  for (int i = 0; i < 5; ++i) {
+    b.close();
+  }
+  Options options;
+  options.nestingLimit = 5;
+
+  Validator validator(&options);
+  ASSERT_VELOCYPACK_EXCEPTION(validator.validate(b.slice().start(), b.slice().byteSize()), Exception::TooDeepNesting);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
this allows restricting the max recursion depth when Parsing JSON or
when validating VPack using a Validator. Helps to prevent stack smashing
attacks via very deeply nested Arrays / Objects.