### PR TITLE
Remove Superflous brackets around GitHub action badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 VelocyPack (VPack) - a fast and compact format for serialization and storage
 ============================================================================
 
-GitHub Action: [![Build](https://github.com/arangodb/velocypack/actions/workflows/github-ci.yml/badge.svg)] Coveralls: [![Coverage Status](https://coveralls.io/repos/arangodb/velocypack/badge.svg?branch=main&service=github)](https://coveralls.io/github/arangodb/velocypack?branch=main)
+GitHub Action: ![Build](https://github.com/arangodb/velocypack/actions/workflows/github-ci.yml/badge.svg) Coveralls: [![Coverage Status](https://coveralls.io/repos/arangodb/velocypack/badge.svg?branch=main&service=github)](https://coveralls.io/github/arangodb/velocypack?branch=main)
 
 Motivation
 ----------


### PR DESCRIPTION
Please note that for legal reasons we require you to sign the 
[Contributor Agreement](https://www.arangodb.com/documents/cla.pdf)
before we can accept your pull requests.

Code changes and contributions in the VelocyPack library should use 
the "Google" style and conventions as used by *clang-format*. 
