### PR TITLE
Make Array/ObjectIterator faster:

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -77,14 +77,15 @@ jobs:
     - name: Install clang
       if: startsWith(matrix.os, 'ubuntu-') && matrix.compiler == 'clang'
       run: |
-        export CODENAME=`lsb_release -c | sed 's/Codename:\t//'`
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get install libunwind-dev
+        sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         version=${{ matrix.version }}
         if [[ $version -ge 13 ]]; then
-          sudo add-apt-repository "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-$version main"
+          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$version main"
         fi
         sudo apt-get update
-        sudo apt-get install clang-$version lld
+        sudo apt-get install clang-$version lld libc++-${clang_version}-dev libc++abi-${clang_version}-dev  
         echo "CC=clang-$version" >> ${GITHUB_ENV}
         echo "CXX=clang++-$version" >> ${GITHUB_ENV}
         echo "LDFLAGS=-fuse-ld=lld" >> ${GITHUB_ENV}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -84,7 +84,7 @@ jobs:
           sudo add-apt-repository "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-$version main"
         fi
         sudo apt-get update
-        sudo apt-get install clang-$version
+        sudo apt-get install clang-$version lld
         echo "CC=clang-$version" >> ${GITHUB_ENV}
         echo "CXX=clang++-$version" >> ${GITHUB_ENV}
         echo "LDFLAGS=-fuse-ld=lld" >> ${GITHUB_ENV}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -85,7 +85,7 @@ jobs:
           sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$version main"
         fi
         sudo apt-get update
-        sudo apt-get install clang-$version lld libc++-${clang_version}-dev libc++abi-${clang_version}-dev  
+        sudo apt-get install clang-$version lld libc++-$version-dev libc++abi-$version-dev  
         echo "CC=clang-$version" >> ${GITHUB_ENV}
         echo "CXX=clang++-$version" >> ${GITHUB_ENV}
         echo "LDFLAGS=-fuse-ld=lld" >> ${GITHUB_ENV}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -23,6 +23,8 @@ jobs:
              build_type: Release, hash_type: fasthash }
           - {os: ubuntu-latest, compiler: gcc, version: '11',
              build_type: Release, hash_type: xxhash }
+          - {os: ubuntu-latest, compiler: gcc, version: '12',
+             build_type: Release, hash_type: fasthash }
           - {os: ubuntu-latest, compiler: gcc, version: '10',
              build_type: Debug, hash_type: xxhash,
              flags: '-O0 -fno-inline --coverage', coverage: true}
@@ -37,6 +39,10 @@ jobs:
           - {os: ubuntu-latest, compiler: clang, version: '11',
              build_type: Release, hash_type: fasthash }
           - {os: ubuntu-latest, compiler: clang, version: '12',
+             build_type: Release, hash_type: xxhash }
+          - {os: ubuntu-latest, compiler: clang, version: '13',
+             build_type: Release, hash_type: fasthash }
+          - {os: ubuntu-latest, compiler: clang, version: '14',
              build_type: Release, hash_type: xxhash }
 
           # Windows builds
@@ -57,7 +63,7 @@ jobs:
 
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup environment
       run: |
         echo "SANITIZER=${{ matrix.sanitizer }}" >> ${GITHUB_ENV}
@@ -73,11 +79,14 @@ jobs:
       run: |
         export CODENAME=`lsb_release -c | sed 's/Codename:\t//'`
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key 2>/dev/null | sudo apt-key add -
-        sudo add-apt-repository "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${{ matrix.version }} main"
+        version=${{ matrix.version }}
+        if [[ $version -ge 13 ]]; then
+          sudo add-apt-repository "deb http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-$version main"
+        fi
         sudo apt-get update
-        sudo apt-get install clang-${{ matrix.version }}
-        echo "CC=clang-${{ matrix.version }}" >> ${GITHUB_ENV}
-        echo "CXX=clang++-${{ matrix.version }}" >> ${GITHUB_ENV}
+        sudo apt-get install clang-$version
+        echo "CC=clang-$version" >> ${GITHUB_ENV}
+        echo "CXX=clang++-$version" >> ${GITHUB_ENV}
         echo "LDFLAGS=-fuse-ld=lld" >> ${GITHUB_ENV}
     - name: Initialize MSVC ${{ matrix.version }}
       if: startsWith(matrix.os, 'windows-')

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -70,8 +70,7 @@ class ArrayIterator {
     return *this;
   }
 
-  [[nodiscard("You made unnecessary expensive copy.")]] ArrayIterator
-  operator++(int) noexcept {
+  [[nodiscard]] ArrayIterator operator++(int) noexcept {
     ArrayIterator prev{*this};
     next();
     return prev;
@@ -233,8 +232,7 @@ class ObjectIterator {
     return *this;
   }
 
-  [[nodiscard("You made unnecessary expensive copy.")]] ObjectIterator
-  operator++(int) noexcept {
+  [[nodiscard]] ObjectIterator operator++(int) noexcept {
     ObjectIterator prev{*this};
     next();
     return prev;
@@ -255,10 +253,7 @@ class ObjectIterator {
     return {key.makeKey(), Slice(key.begin() + key.byteSize())};
   }
 
-  [[nodiscard("You made unnecessary expensive copy.")]] ObjectIterator begin()
-      const noexcept {
-    return {*this};
-  }
+  [[nodiscard]] ObjectIterator begin() const noexcept { return {*this}; }
 
 #if (defined(_MSC_VER) ||                                     \
      (defined(__clang_version__) && __clang_major__ >= 12) || \

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -185,8 +185,8 @@ class ArrayIterator {
       return nullptr;
     }
     auto const head = _slice.head();
-    VELOCYPACK_ASSERT(head != 0x0a);  // no empty object allowed here
-    if (head == 0x14) {
+    VELOCYPACK_ASSERT(head != 0x01);  // no empty array allowed here
+    if (head == 0x13) {
       return _slice.start() + _slice.getStartOffsetFromCompact();
     }
     return _slice.begin() + _slice.findDataOffset(head);

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -65,13 +65,11 @@ class ArrayIterator {
     _current = first();
   }
 
-  // prefix ++
   ArrayIterator& operator++() noexcept {
     next();
     return *this;
   }
 
-  // postfix ++
   [[nodiscard("You made unnecessary expensive copy.")]] ArrayIterator
   operator++(int) noexcept {
     ArrayIterator prev{*this};
@@ -230,13 +228,11 @@ class ObjectIterator {
     _current = first(useSequentialIteration);
   }
 
-  // prefix ++
   ObjectIterator& operator++() noexcept {
     next();
     return *this;
   }
 
-  // postfix ++
   [[nodiscard("You made unnecessary expensive copy.")]] ObjectIterator
   operator++(int) noexcept {
     ObjectIterator prev{*this};

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -82,17 +82,25 @@ class ArrayIterator {
   [[nodiscard]] bool operator==(ArrayIterator const& other) const noexcept {
     return _position == other._position;
   }
-  [[nodiscard]] bool operator==(std::default_sentinel_t) const noexcept {
-    return !valid();
-  }
 
   [[nodiscard]] Slice operator*() const { return value(); }
 
-  [[nodiscard]] ArrayIterator begin() const noexcept {
-    return {*this};
-  }
+  [[nodiscard]] ArrayIterator begin() const noexcept { return {*this}; }
 
+#if (defined(_MSC_VER) ||                                     \
+     (defined(__clang_version__) && __clang_major__ >= 12) || \
+     (!defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 10))
   [[nodiscard]] std::default_sentinel_t end() const noexcept { return {}; }
+  [[nodiscard]] bool operator==(std::default_sentinel_t) const noexcept {
+    return !valid();
+  }
+#else
+  [[nodiscard]] ArrayIterator end() const noexcept {
+    ArrayIterator it{*this};
+    it._position = it._size;
+    return it;
+  }
+#endif
 
   [[nodiscard]] bool valid() const noexcept { return _position != _size; }
 
@@ -239,9 +247,6 @@ class ObjectIterator {
   [[nodiscard]] bool operator==(ObjectIterator const& other) const noexcept {
     return _position == other._position;
   }
-  [[nodiscard]] bool operator==(std::default_sentinel_t) const noexcept {
-    return !valid();
-  }
 
   [[nodiscard]] ObjectPair operator*() const {
     if (_current != nullptr) {
@@ -259,7 +264,20 @@ class ObjectIterator {
     return {*this};
   }
 
+#if (defined(_MSC_VER) ||                                     \
+     (defined(__clang_version__) && __clang_major__ >= 12) || \
+     (!defined(__clang__) && defined(__GNUC__) && __GNUC__ >= 10))
+  [[nodiscard]] bool operator==(std::default_sentinel_t) const noexcept {
+    return !valid();
+  }
   [[nodiscard]] std::default_sentinel_t end() const noexcept { return {}; }
+#else
+  [[nodiscard]] ObjectIterator end() const noexcept {
+    ObjectIterator it{*this};
+    it._position = it._size;
+    return it;
+  }
+#endif
 
   [[nodiscard]] bool valid() const noexcept { return _position != _size; }
 

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -271,6 +271,9 @@ class ObjectIterator {
     it._position = it._size;
     return it;
   }
+  [[nodiscard]] bool operator!=(ObjectIterator const& other) const noexcept {
+    return !operator==(other);
+  }
 #endif
 
   [[nodiscard]] bool valid() const noexcept { return _position != _size; }

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <cstdint>
+#include <iterator>
 #include <iosfwd>
 #include <tuple>
 
@@ -49,123 +50,110 @@ class ArrayIterator {
 
   // optimization for an empty array
   explicit ArrayIterator(Empty) noexcept
-      : _slice(Slice::emptyArraySlice()),
-        _size(0),
-        _position(0),
-        _current(nullptr),
-        _first(nullptr) {}
+      : _slice{Slice::emptyArraySlice()},
+        _current{nullptr},
+        _size{0},
+        _position{0} {}
 
   explicit ArrayIterator(Slice slice)
-      : _slice(slice),
-        _size(0),
-        _position(0),
-        _current(nullptr),
-        _first(nullptr) {
-    uint8_t const head = slice.head();
-
+      : _slice{slice}, _current{nullptr}, _size{0}, _position{0} {
+    auto const head = slice.head();
     if (VELOCYPACK_UNLIKELY(slice.type(head) != ValueType::Array)) {
-      throw Exception(Exception::InvalidValueType, "Expecting Array slice");
+      throw Exception{Exception::InvalidValueType, "Expecting Array slice"};
     }
-
     _size = slice.arrayLength();
-
-    if (_size > 0) {
-      VELOCYPACK_ASSERT(head != 0x01);  // no empty array allowed here
-      if (head == 0x13) {
-        _current = slice.start() + slice.getStartOffsetFromCompact();
-      } else {
-        _current = slice.begin() + slice.findDataOffset(head);
-      }
-      _first = _current;
-    }
+    _current = first();
   }
 
   // prefix ++
-  ArrayIterator& operator++() {
-    ++_position;
-    if (_position < _size && _current != nullptr) {
-      _current += Slice(_current).byteSize();
-    } else {
-      _current = nullptr;
-    }
+  ArrayIterator& operator++() noexcept {
+    next();
     return *this;
   }
 
   // postfix ++
-  ArrayIterator operator++(int) {
-    ArrayIterator result(*this);
-    ++(*this);
-    return result;
+  [[nodiscard("You made unnecessary expensive copy.")]] ArrayIterator
+  operator++(int) noexcept {
+    ArrayIterator prev{*this};
+    next();
+    return prev;
   }
 
-  bool operator==(ArrayIterator const& other) const noexcept {
+  [[nodiscard]] bool operator==(ArrayIterator const& other) const noexcept {
     return _position == other._position;
   }
-  bool operator!=(ArrayIterator const& other) const noexcept {
-    return !operator==(other);
+  [[nodiscard]] bool operator==(std::default_sentinel_t) const noexcept {
+    return !valid();
   }
 
-  Slice operator*() const {
-    if (_current != nullptr) {
-      return Slice(_current);
+  [[nodiscard]] Slice operator*() const { return value(); }
+
+  [[nodiscard]] ArrayIterator begin() const noexcept {
+    return {*this};
+  }
+
+  [[nodiscard]] std::default_sentinel_t end() const noexcept { return {}; }
+
+  [[nodiscard]] bool valid() const noexcept { return _position != _size; }
+
+  [[nodiscard]] Slice value() const {
+    if (VELOCYPACK_UNLIKELY(!valid())) {
+      throw Exception{Exception::IndexOutOfBounds};
     }
-    // intentionally no out-of-bounds checking here, as it will
-    // be performed by Slice::getNthOffset()
-    return Slice(_slice.begin() + _slice.getNthOffset(_position));
+    VELOCYPACK_ASSERT(_current != nullptr);
+    return Slice{_current};
   }
 
-  ArrayIterator begin() const {
-    auto it = ArrayIterator(*this);
-    it._position = 0;
-    return it;
+  void next() noexcept {
+    if (VELOCYPACK_UNLIKELY(!valid())) {
+      return;
+    }
+    ++_position;
+    VELOCYPACK_ASSERT(_current != nullptr);
+    _current += Slice(_current).byteSize();
   }
 
-  ArrayIterator end() const {
-    auto it = ArrayIterator(*this);
-    it._position = it._size;
-    return it;
+  [[nodiscard]] ValueLength index() const noexcept { return _position; }
+
+  [[nodiscard]] ValueLength size() const noexcept { return _size; }
+
+  [[deprecated(
+      "Dangerous API, you don't really know valid or not. "
+      "You can use index() and size().")]] bool
+  isFirst() const noexcept {
+    return _position == 0;
   }
 
-  inline bool valid() const noexcept { return (_position < _size); }
+  [[deprecated(
+      "Dangerous API, you don't really know valid or not. "
+      "You can use index() and size().")]] bool
+  isLast() const noexcept {
+    return _position + 1 >= _size;
+  }
 
-  inline Slice value() const { return operator*(); }
-
-  inline void next() { operator++(); }
-
-  inline ValueLength index() const noexcept { return _position; }
-
-  inline ValueLength size() const noexcept { return _size; }
-
-  inline bool isFirst() const noexcept { return (_position == 0); }
-
-  inline bool isLast() const noexcept { return (_position + 1 >= _size); }
-
-  inline void forward(ValueLength count) {
-    if (_position + count >= _size) {
-      // beyond end of data
-      _current = nullptr;
+  void forward(ValueLength count) noexcept {
+    _position += count;
+    if (VELOCYPACK_UNLIKELY(_position >= _size)) {
       _position = _size;
-    } else {
-      auto h = _slice.head();
-      if (h == 0x13) {
-        while (count-- > 0) {
-          _current += Slice(_current).byteSize();
-          ++_position;
-        }
-      } else {
-        _position += count;
-        _current = _slice.at(_position).start();
+      return;
+    }
+    auto const head = _slice.head();
+    if (head == 0x13) {
+      while (count-- != 0) {
+        _current += Slice(_current).byteSize();
       }
+    } else {
+      _current = _slice.at(_position).start();
     }
   }
 
-  inline void reset() {
+  void reset() noexcept {
     _position = 0;
-    _current = _first;
+    _current = first();
   }
 
   template<typename... Ts>
-  std::tuple<Ts...> unpackPrefixAsTuple() {
+  [[nodiscard]] std::tuple<Ts...> unpackPrefixAsTuple() {
     return unpackTupleInternal(unpack_helper<Ts...>{});
   }
 
@@ -174,27 +162,37 @@ class ArrayIterator {
   struct unpack_helper {};
 
   template<typename T, typename... Ts>
-  std::tuple<T, Ts...> unpackTupleInternal(unpack_helper<T, Ts...>) {
+  [[nodiscard]] std::tuple<T, Ts...> unpackTupleInternal(
+      unpack_helper<T, Ts...>) {
     auto slice = value();  // this does out-of-bounds checking
     next();
     return std::tuple_cat(std::make_tuple(slice.extract<T>()),
                           unpackTupleInternal(unpack_helper<Ts...>{}));
   }
 
-  std::tuple<> unpackTupleInternal(unpack_helper<>) const {
+  [[nodiscard]] static std::tuple<> unpackTupleInternal(unpack_helper<>) {
     return std::make_tuple<>();
   }
 
+  [[nodiscard]] uint8_t const* first() const noexcept {
+    if (VELOCYPACK_UNLIKELY(_size == 0)) {
+      return nullptr;
+    }
+    auto const head = _slice.head();
+    VELOCYPACK_ASSERT(head != 0x0a);  // no empty object allowed here
+    if (head == 0x14) {
+      return _slice.start() + _slice.getStartOffsetFromCompact();
+    }
+    return _slice.begin() + _slice.findDataOffset(head);
+  }
+
   Slice _slice;
+  uint8_t const* _current;
   ValueLength _size;
   ValueLength _position;
-  uint8_t const* _current;
-  uint8_t const* _first;
 };
 
 struct ObjectIteratorPair {
-  ObjectIteratorPair(Slice key, Slice value) noexcept
-      : key(key), value(value) {}
   Slice const key;
   Slice const value;
 };
@@ -215,96 +213,70 @@ class ObjectIterator {
   // simply jumps from key/value pair to key/value pair without using the
   // index. The default `false` is to use the index if it is there.
   explicit ObjectIterator(Slice slice, bool useSequentialIteration = false)
-      : _slice(slice),
-        _size(0),
-        _position(0),
-        _current(nullptr),
-        _first(nullptr) {
-    uint8_t const head = slice.head();
-
+      : _slice{slice}, _current{nullptr}, _size{0}, _position{0} {
+    auto const head = slice.head();
     if (VELOCYPACK_UNLIKELY(slice.type(head) != ValueType::Object)) {
-      throw Exception(Exception::InvalidValueType, "Expecting Object slice");
+      throw Exception{Exception::InvalidValueType, "Expecting Object slice"};
     }
-
     _size = slice.objectLength();
-
-    if (_size > 0) {
-      VELOCYPACK_ASSERT(head != 0x0a);  // no empty object allowed here
-      if (head == 0x14) {
-        _current = slice.start() + slice.getStartOffsetFromCompact();
-      } else if (useSequentialIteration) {
-        _current = slice.begin() + slice.findDataOffset(head);
-      }
-      _first = _current;
-    }
+    _current = first(useSequentialIteration);
   }
 
   // prefix ++
-  ObjectIterator& operator++() {
-    ++_position;
-    if (_position < _size && _current != nullptr) {
-      // skip over key
-      _current += Slice(_current).byteSize();
-      // skip over value
-      _current += Slice(_current).byteSize();
-    } else {
-      _current = nullptr;
-    }
+  ObjectIterator& operator++() noexcept {
+    next();
     return *this;
   }
 
   // postfix ++
-  ObjectIterator operator++(int) {
-    ObjectIterator result(*this);
-    ++(*this);
-    return result;
+  [[nodiscard("You made unnecessary expensive copy.")]] ObjectIterator
+  operator++(int) noexcept {
+    ObjectIterator prev{*this};
+    next();
+    return prev;
   }
 
-  bool operator==(ObjectIterator const& other) const {
+  [[nodiscard]] bool operator==(ObjectIterator const& other) const noexcept {
     return _position == other._position;
   }
-
-  bool operator!=(ObjectIterator const& other) const {
-    return !operator==(other);
+  [[nodiscard]] bool operator==(std::default_sentinel_t) const noexcept {
+    return !valid();
   }
 
-  ObjectPair operator*() const {
+  [[nodiscard]] ObjectPair operator*() const {
     if (_current != nullptr) {
-      Slice key(_current);
-      return ObjectPair(key.makeKey(), Slice(_current + key.byteSize()));
+      Slice key{_current};
+      return {key.makeKey(), Slice(_current + key.byteSize())};
     }
-    Slice key(_slice.getNthKeyUntranslated(_position));
-    return ObjectPair(key.makeKey(), Slice(key.begin() + key.byteSize()));
+    // intentionally no out-of-bounds checking here,
+    // as it will be performed by Slice::getNthOffset()
+    Slice key{_slice.getNthKeyUntranslated(_position)};
+    return {key.makeKey(), Slice(key.begin() + key.byteSize())};
   }
 
-  ObjectIterator begin() const {
-    auto it = ObjectIterator(*this);
-    it._position = 0;
-    return it;
+  [[nodiscard("You made unnecessary expensive copy.")]] ObjectIterator begin()
+      const noexcept {
+    return {*this};
   }
 
-  ObjectIterator end() const {
-    auto it = ObjectIterator(*this);
-    it._position = it._size;
-    return it;
-  }
+  [[nodiscard]] std::default_sentinel_t end() const noexcept { return {}; }
 
-  inline bool valid() const noexcept { return (_position < _size); }
+  [[nodiscard]] bool valid() const noexcept { return _position != _size; }
 
-  inline Slice key(bool translate = true) const {
-    if (VELOCYPACK_UNLIKELY(_position >= _size)) {
-      throw Exception(Exception::IndexOutOfBounds);
+  [[nodiscard]] Slice key(bool translate = true) const {
+    if (VELOCYPACK_UNLIKELY(!valid())) {
+      throw Exception{Exception::IndexOutOfBounds};
     }
     if (_current != nullptr) {
-      Slice s(_current);
+      Slice s{_current};
       return translate ? s.makeKey() : s;
     }
     return _slice.getNthKey(_position, translate);
   }
 
-  inline Slice value() const {
-    if (VELOCYPACK_UNLIKELY(_position >= _size)) {
-      throw Exception(Exception::IndexOutOfBounds);
+  [[nodiscard]] Slice value() const {
+    if (VELOCYPACK_UNLIKELY(!valid())) {
+      throw Exception{Exception::IndexOutOfBounds};
     }
     if (_current != nullptr) {
       Slice key(_current);
@@ -313,27 +285,61 @@ class ObjectIterator {
     return _slice.getNthValue(_position);
   }
 
-  inline void next() { operator++(); }
+  void next() noexcept {
+    if (VELOCYPACK_UNLIKELY(!valid())) {
+      return;
+    }
+    ++_position;
+    if (_current != nullptr) {
+      // skip over key
+      _current += Slice(_current).byteSize();
+      // skip over value
+      _current += Slice(_current).byteSize();
+    }
+  }
 
-  inline ValueLength index() const noexcept { return _position; }
+  [[nodiscard]] ValueLength index() const noexcept { return _position; }
 
-  inline ValueLength size() const noexcept { return _size; }
+  [[nodiscard]] ValueLength size() const noexcept { return _size; }
 
-  inline bool isFirst() const noexcept { return (_position == 0); }
+  [[deprecated(
+      "Dangerous API, you don't really know valid or not. "
+      "You can use index() and size().")]] [[nodiscard]] bool
+  isFirst() const noexcept {
+    return _position == 0;
+  }
 
-  inline bool isLast() const noexcept { return (_position + 1 >= _size); }
+  [[deprecated(
+      "Dangerous API, you don't really know valid or not. "
+      "You can use index() and size().")]] [[nodiscard]] bool
+  isLast() const noexcept {
+    return _position + 1 >= _size;
+  }
 
-  inline void reset() {
+  void reset() noexcept {
     _position = 0;
-    _current = _first;
+    _current = first(_current != nullptr);
   }
 
  private:
+  [[nodiscard]] uint8_t const* first(bool useSequentialIteration) noexcept {
+    if (VELOCYPACK_UNLIKELY(_size == 0)) {
+      return nullptr;
+    }
+    auto const head = _slice.head();
+    VELOCYPACK_ASSERT(head != 0x0a);  // no empty object allowed here
+    if (head == 0x14) {
+      return _slice.start() + _slice.getStartOffsetFromCompact();
+    } else if (useSequentialIteration) {
+      return _slice.begin() + _slice.findDataOffset(head);
+    }
+    return nullptr;
+  }
+
   Slice _slice;
+  uint8_t const* _current;
   ValueLength _size;
   ValueLength _position;
-  uint8_t const* _current;
-  uint8_t const* _first;
 };
 
 }  // namespace arangodb::velocypack

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -97,6 +97,9 @@ class ArrayIterator {
     it._position = it._size;
     return it;
   }
+  [[nodiscard]] bool operator!=(ArrayIterator const& other) const noexcept {
+    return !operator==(other);
+  }
 #endif
 
   [[nodiscard]] bool valid() const noexcept { return _position != _size; }

--- a/tests/testsIterator.cpp
+++ b/tests/testsIterator.cpp
@@ -84,12 +84,13 @@ TEST(IteratorTest, IterateArrayEmpty) {
   ASSERT_EQ(0U, it.size());
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION((*it), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = (*it), Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateArrayEmptySpecial) {
@@ -97,12 +98,13 @@ TEST(IteratorTest, IterateArrayEmptySpecial) {
   ASSERT_EQ(0U, it.size());
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION((*it), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = (*it), Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateArray) {
@@ -171,7 +173,8 @@ TEST(IteratorTest, IterateArray) {
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateArrayForward) {
@@ -230,7 +233,8 @@ TEST(IteratorTest, IterateArrayForward) {
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateCompactArrayForward) {
@@ -292,7 +296,8 @@ TEST(IteratorTest, IterateCompactArrayForward) {
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateSubArray) {
@@ -332,7 +337,8 @@ TEST(IteratorTest, IterateSubArray) {
 
   it2.next();
   ASSERT_FALSE(it2.valid());
-  ASSERT_VELOCYPACK_EXCEPTION(it2.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it2.value(),
+                              Exception::IndexOutOfBounds);
 
   it.next();
 
@@ -357,11 +363,13 @@ TEST(IteratorTest, IterateSubArray) {
 
   it3.next();
   ASSERT_FALSE(it3.valid());
-  ASSERT_VELOCYPACK_EXCEPTION(it3.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it3.value(),
+                              Exception::IndexOutOfBounds);
 
   it.next();
   ASSERT_FALSE(it.valid());
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateArrayUnsorted) {
@@ -430,7 +438,8 @@ TEST(IteratorTest, IterateArrayUnsorted) {
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateNonObject1) {
@@ -488,8 +497,10 @@ TEST(IteratorTest, IterateObjectEmpty) {
   ObjectIterator it(s);
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.key(), Exception::IndexOutOfBounds);
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.key(),
+                              Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 
   it.next();
   ASSERT_FALSE(it.valid());
@@ -578,8 +589,10 @@ TEST(IteratorTest, IterateObject) {
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.key(), Exception::IndexOutOfBounds);
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.key(),
+                              Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateObjectUnsorted) {
@@ -710,8 +723,10 @@ TEST(IteratorTest, IterateObjectCompact) {
   it.next();
   ASSERT_FALSE(it.valid());
 
-  ASSERT_VELOCYPACK_EXCEPTION(it.key(), Exception::IndexOutOfBounds);
-  ASSERT_VELOCYPACK_EXCEPTION(it.value(), Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.key(),
+                              Exception::IndexOutOfBounds);
+  ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.value(),
+                              Exception::IndexOutOfBounds);
 }
 
 TEST(IteratorTest, IterateObjectKeys) {
@@ -1171,7 +1186,7 @@ TEST(IteratorTest, ArrayIteratorToStream) {
   {
     std::ostringstream result;
     result << it;
-    ASSERT_EQ("[ArrayIterator 6 / 5]", result.str());
+    ASSERT_EQ("[ArrayIterator 5 / 5]", result.str());
   }
 }
 
@@ -1211,7 +1226,7 @@ TEST(IteratorTest, ObjectIteratorToStream) {
   {
     std::ostringstream result;
     result << it;
-    ASSERT_EQ("[ObjectIterator 4 / 3]", result.str());
+    ASSERT_EQ("[ObjectIterator 3 / 3]", result.str());
   }
 }
 


### PR DESCRIPTION
* Decrease sizeof: 32 bytes instead of 48 bytes on 64 bit machine. But makes `reset()` more expensive
* `end()` return `default_sentinel_t` -- empty class
* Fix bug in `begin()` if we want reset `_position` to zero needs also reset `_current` to `_first`, but we don't do it, so we don't have such bugs and `_position` always was zero in our code. 
   We want to keep this behavior because it's explicit, and with it we can avoid twice first() call.
* ArrayIterator always have `_current` so it `operator*()`/`operator++()` can be implemented with less condition count
* Deprecate unclear API: isFirst/isLast
* Don't increment `_position` if we rich `_size`, it's strange, also in such case I can overflow it (mostly in theory).


Needs check before merge in arangodb and iresearch

- [ ] PR in iresearch: TODO(MBkkt)
- [ ] PR in arangodb: TODO(MBkkt)