### PR TITLE
remove default parameter from ObjectIterator ctor

### DIFF
--- a/examples/exampleAttributeTranslation.cpp
+++ b/examples/exampleAttributeTranslation.cpp
@@ -17,8 +17,8 @@ static void printObject(Builder const& b) {
   // now iterate over the object members
   // the attribute name translator works transparently
   std::cout << "Iterating Object members:" << std::endl;
-  for (auto const& it : ObjectIterator(s)) {
-    std::cout << "key: " << it.key.copyString()
+  for (auto const& it : ObjectIterator(s, /*useSequentialIteration*/ true)) {
+    std::cout << "key: " << it.key.stringView()
               << ", value: " << it.value.toJson() << std::endl;
   }
 }

--- a/examples/exampleObjectIterator.cpp
+++ b/examples/exampleObjectIterator.cpp
@@ -31,8 +31,8 @@ int main(int, char*[]) {
 
   // now iterate over the object members
   std::cout << "Iterating Object members:" << std::endl;
-  for (auto const& it : ObjectIterator(s)) {
-    std::cout << "key: " << it.key.copyString() << ", value: " << it.value
+  for (auto const& it : ObjectIterator(s, /*useSequentialIteration*/ true)) {
+    std::cout << "key: " << it.key.stringView() << ", value: " << it.value
               << std::endl;
   }
 

--- a/include/velocypack/Iterator.h
+++ b/include/velocypack/Iterator.h
@@ -220,7 +220,7 @@ class ObjectIterator {
   // The useSequentialIteration flag indicates whether or not the iteration
   // simply jumps from key/value pair to key/value pair without using the
   // index. The default `false` is to use the index if it is there.
-  explicit ObjectIterator(Slice slice, bool useSequentialIteration = false)
+  explicit ObjectIterator(Slice slice, bool useSequentialIteration)
       : _slice{slice}, _current{nullptr}, _size{0}, _position{0} {
     auto const head = slice.head();
     if (VELOCYPACK_UNLIKELY(slice.type(head) != ValueType::Object)) {
@@ -337,7 +337,7 @@ class ObjectIterator {
   }
 
  private:
-  [[nodiscard]] uint8_t const* first(bool useSequentialIteration) noexcept {
+  [[nodiscard]] uint8_t const* first(bool useSequentialIteration) const noexcept {
     if (VELOCYPACK_UNLIKELY(_size == 0)) {
       return nullptr;
     }
@@ -346,7 +346,7 @@ class ObjectIterator {
     if (head == 0x14) {
       return _slice.start() + _slice.getStartOffsetFromCompact();
     } else if (useSequentialIteration) {
-      return _slice.begin() + _slice.findDataOffset(head);
+      return _slice.start() + _slice.findDataOffset(head);
     }
     return nullptr;
   }

--- a/include/velocypack/velocypack-version-number.h
+++ b/include/velocypack/velocypack-version-number.h
@@ -1,8 +1,8 @@
 // this is an auto-generated file. do not edit!
 
 #pragma once
-#define VELOCYPACK_VERSION "0.2.0"
+#define VELOCYPACK_VERSION "0.2.1"
 
 #define VELOCYPACK_VERSION_MAJOR 0
 #define VELOCYPACK_VERSION_MINOR 2
-#define VELOCYPACK_VERSION_PATCH 0
+#define VELOCYPACK_VERSION_PATCH 1

--- a/src/AttributeTranslator.cpp
+++ b/src/AttributeTranslator.cpp
@@ -54,10 +54,10 @@ void AttributeTranslator::seal() {
 
   Slice s(_builder->slice());
 
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ true);
 
   while (it.valid()) {
-    Slice const key(it.key(false));
+    Slice key(it.key(false));
     VELOCYPACK_ASSERT(key.isString());
 
     // insert into string and char lookup maps

--- a/src/Collection.cpp
+++ b/src/Collection.cpp
@@ -35,11 +35,8 @@
 
 using namespace arangodb::velocypack;
 
-// indicator for "element not found" in indexOf() method
-ValueLength const Collection::NotFound = UINT64_MAX;
-
 // fully append an array to the builder
-Builder& Collection::appendArray(Builder& builder, Slice const& slice) {
+Builder& Collection::appendArray(Builder& builder, Slice slice) {
   ArrayIterator it(slice);
 
   while (it.valid()) {
@@ -60,7 +57,7 @@ static inline std::unordered_set<std::string> makeSet(
   return s;
 }
 
-void Collection::forEach(Slice const& slice, Predicate const& predicate) {
+void Collection::forEach(Slice slice, Predicate const& predicate) {
   ArrayIterator it(slice);
   ValueLength index = 0;
 
@@ -74,7 +71,7 @@ void Collection::forEach(Slice const& slice, Predicate const& predicate) {
   }
 }
 
-Builder Collection::filter(Slice const& slice, Predicate const& predicate) {
+Builder Collection::filter(Slice slice, Predicate const& predicate) {
   // construct a new Array
   Builder b;
   b.add(Value(ValueType::Array));
@@ -94,7 +91,7 @@ Builder Collection::filter(Slice const& slice, Predicate const& predicate) {
   return b;
 }
 
-Slice Collection::find(Slice const& slice, Predicate const& predicate) {
+Slice Collection::find(Slice slice, Predicate const& predicate) {
   ArrayIterator it(slice);
   ValueLength index = 0;
 
@@ -110,7 +107,7 @@ Slice Collection::find(Slice const& slice, Predicate const& predicate) {
   return Slice();
 }
 
-bool Collection::contains(Slice const& slice, Predicate const& predicate) {
+bool Collection::contains(Slice slice, Predicate const& predicate) {
   ArrayIterator it(slice);
   ValueLength index = 0;
 
@@ -126,7 +123,7 @@ bool Collection::contains(Slice const& slice, Predicate const& predicate) {
   return false;
 }
 
-bool Collection::contains(Slice const& slice, Slice const& other) {
+bool Collection::contains(Slice slice, Slice other) {
   ArrayIterator it(slice);
 
   while (it.valid()) {
@@ -139,7 +136,7 @@ bool Collection::contains(Slice const& slice, Slice const& other) {
   return false;
 }
 
-ValueLength Collection::indexOf(Slice const& slice, Slice const& other) {
+ValueLength Collection::indexOf(Slice slice, Slice other) {
   ArrayIterator it(slice);
   ValueLength index = 0;
 
@@ -154,7 +151,7 @@ ValueLength Collection::indexOf(Slice const& slice, Slice const& other) {
   return Collection::NotFound;
 }
 
-bool Collection::all(Slice const& slice, Predicate const& predicate) {
+bool Collection::all(Slice slice, Predicate const& predicate) {
   ArrayIterator it(slice);
   ValueLength index = 0;
 
@@ -170,7 +167,7 @@ bool Collection::all(Slice const& slice, Predicate const& predicate) {
   return true;
 }
 
-bool Collection::any(Slice const& slice, Predicate const& predicate) {
+bool Collection::any(Slice slice, Predicate const& predicate) {
   ArrayIterator it(slice);
   ValueLength index = 0;
 
@@ -186,7 +183,7 @@ bool Collection::any(Slice const& slice, Predicate const& predicate) {
   return false;
 }
 
-std::vector<std::string> Collection::keys(Slice const& slice) {
+std::vector<std::string> Collection::keys(Slice slice) {
   std::vector<std::string> result;
 
   keys(slice, result);
@@ -194,7 +191,7 @@ std::vector<std::string> Collection::keys(Slice const& slice) {
   return result;
 }
 
-Builder Collection::concat(Slice const& slice1, Slice const& slice2) {
+Builder Collection::concat(Slice slice1, Slice slice2) {
   Builder b;
   b.openArray();
   appendArray(b, slice1);
@@ -204,7 +201,7 @@ Builder Collection::concat(Slice const& slice1, Slice const& slice2) {
   return b;
 }
 
-Builder Collection::extract(Slice const& slice, int64_t from, int64_t to) {
+Builder Collection::extract(Slice slice, int64_t from, int64_t to) {
   Builder b;
   b.openArray();
 
@@ -234,11 +231,11 @@ Builder Collection::extract(Slice const& slice, int64_t from, int64_t to) {
   return b;
 }
 
-Builder Collection::values(Slice const& slice) {
+Builder Collection::values(Slice slice) {
   Builder b;
   b.add(Value(ValueType::Array));
 
-  ObjectIterator it(slice);
+  ObjectIterator it(slice, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     b.add(it.value());
@@ -249,7 +246,7 @@ Builder Collection::values(Slice const& slice) {
   return b;
 }
 
-Builder Collection::keep(Slice const& slice,
+Builder Collection::keep(Slice slice,
                          std::vector<std::string> const& keys) {
   // check if there are so many keys that we want to use the hash-based version
   // cut-off values are arbitrary...
@@ -260,7 +257,7 @@ Builder Collection::keep(Slice const& slice,
   Builder b;
   b.add(Value(ValueType::Object));
 
-  ObjectIterator it(slice);
+  ObjectIterator it(slice, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     auto key = it.key(true).copyString();
@@ -274,12 +271,12 @@ Builder Collection::keep(Slice const& slice,
   return b;
 }
 
-Builder Collection::keep(Slice const& slice,
+Builder Collection::keep(Slice slice,
                          std::unordered_set<std::string> const& keys) {
   Builder b;
   b.add(Value(ValueType::Object));
 
-  ObjectIterator it(slice);
+  ObjectIterator it(slice, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     auto key = it.key(true).copyString();
@@ -293,7 +290,7 @@ Builder Collection::keep(Slice const& slice,
   return b;
 }
 
-Builder Collection::remove(Slice const& slice,
+Builder Collection::remove(Slice slice,
                            std::vector<std::string> const& keys) {
   // check if there are so many keys that we want to use the hash-based version
   // cut-off values are arbitrary...
@@ -304,7 +301,7 @@ Builder Collection::remove(Slice const& slice,
   Builder b;
   b.add(Value(ValueType::Object));
 
-  ObjectIterator it(slice);
+  ObjectIterator it(slice, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     auto key = it.key(true).copyString();
@@ -318,12 +315,12 @@ Builder Collection::remove(Slice const& slice,
   return b;
 }
 
-Builder Collection::remove(Slice const& slice,
+Builder Collection::remove(Slice slice,
                            std::unordered_set<std::string> const& keys) {
   Builder b;
   b.add(Value(ValueType::Object));
 
-  ObjectIterator it(slice);
+  ObjectIterator it(slice, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     auto key = it.key(true).copyString();
@@ -337,7 +334,7 @@ Builder Collection::remove(Slice const& slice,
   return b;
 }
 
-Builder Collection::merge(Slice const& left, Slice const& right,
+Builder Collection::merge(Slice left, Slice right,
                           bool mergeValues, bool nullMeansRemove) {
   if (!left.isObject() || !right.isObject()) {
     throw Exception(Exception::InvalidValueType, "Expecting type Object");
@@ -348,8 +345,8 @@ Builder Collection::merge(Slice const& left, Slice const& right,
   return b;
 }
 
-Builder& Collection::merge(Builder& builder, Slice const& left,
-                           Slice const& right, bool mergeValues,
+Builder& Collection::merge(Builder& builder, Slice left,
+                           Slice right, bool mergeValues,
                            bool nullMeansRemove) {
   if (!left.isObject() || !right.isObject()) {
     throw Exception(Exception::InvalidValueType, "Expecting type Object");
@@ -359,7 +356,7 @@ Builder& Collection::merge(Builder& builder, Slice const& left,
 
   std::unordered_map<std::string_view, Slice> rightValues;
   {
-    ObjectIterator it(right);
+    ObjectIterator it(right, /*useSequentialIteration*/ true);
     while (it.valid()) {
       auto current = (*it);
       rightValues.emplace(current.key.stringView(), current.value);
@@ -368,7 +365,7 @@ Builder& Collection::merge(Builder& builder, Slice const& left,
   }
 
   {
-    ObjectIterator it(left);
+    ObjectIterator it(left, /*useSequentialIteration*/ false);
 
     while (it.valid()) {
       auto current = (*it);
@@ -420,14 +417,14 @@ Builder& Collection::merge(Builder& builder, Slice const& left,
 
 template<Collection::VisitationOrder order>
 static bool doVisit(
-    Slice const& slice,
-    std::function<bool(Slice const& key, Slice const& value)> const& func);
+    Slice slice,
+    std::function<bool(Slice key, Slice value)> const& func);
 
 template<Collection::VisitationOrder order>
 static bool visitObject(
-    Slice const& value,
-    std::function<bool(Slice const& key, Slice const& value)> const& func) {
-  ObjectIterator it(value);
+    Slice value,
+    std::function<bool(Slice key, Slice value)> const& func) {
+  ObjectIterator it(value, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     auto current = (*it);
@@ -458,8 +455,8 @@ static bool visitObject(
 
 template<Collection::VisitationOrder order>
 static bool visitArray(
-    Slice const& value,
-    std::function<bool(Slice const& key, Slice const& value)> const& func) {
+    Slice value,
+    std::function<bool(Slice key, Slice value)> const& func) {
   ArrayIterator it(value);
 
   while (it.valid()) {
@@ -491,8 +488,8 @@ static bool visitArray(
 
 template<Collection::VisitationOrder order>
 static bool doVisit(
-    Slice const& slice,
-    std::function<bool(Slice const& key, Slice const& value)> const& func) {
+    Slice slice,
+    std::function<bool(Slice key, Slice value)> const& func) {
   if (slice.isObject()) {
     return visitObject<order>(slice, func);
   }
@@ -505,8 +502,8 @@ static bool doVisit(
 }
 
 void Collection::visitRecursive(
-    Slice const& slice, Collection::VisitationOrder order,
-    std::function<bool(Slice const&, Slice const&)> const& func) {
+    Slice slice, Collection::VisitationOrder order,
+    std::function<bool(Slice, Slice)> const& func) {
   if (order == Collection::PreOrder) {
     doVisit<Collection::PreOrder>(slice, func);
   } else {
@@ -515,8 +512,8 @@ void Collection::visitRecursive(
 }
 
 Builder Collection::sort(
-    Slice const& array,
-    std::function<bool(Slice const&, Slice const&)> lessthan) {
+    Slice array,
+    std::function<bool(Slice, Slice)> lessthan) {
   if (!array.isArray()) {
     throw Exception(Exception::InvalidValueType, "Expecting type Array");
   }

--- a/src/Slice.cpp
+++ b/src/Slice.cpp
@@ -482,7 +482,7 @@ bool Slice::isEqualStringUnchecked(std::string_view attribute) const noexcept {
 }
 
 Slice Slice::getFromCompactObject(std::string_view attribute) const {
-  ObjectIterator it(*this);
+  ObjectIterator it(*this, /*useSequentialIteration*/ false);
   while (it.valid()) {
     Slice key = it.key(false);
     if (key.makeKey().isEqualString(attribute)) {

--- a/tests/testsBuilder.cpp
+++ b/tests/testsBuilder.cpp
@@ -72,7 +72,7 @@ TEST(BuilderTest, AddObjectIteratorEmpty) {
 
   Builder b;
   ASSERT_TRUE(b.isClosed());
-  ASSERT_VELOCYPACK_EXCEPTION(b.add(ObjectIterator(objSlice)),
+  ASSERT_VELOCYPACK_EXCEPTION(b.add(ObjectIterator(objSlice, /*useSequentialIteration*/ false)),
                               Exception::BuilderNeedOpenObject);
   ASSERT_TRUE(b.isClosed());
 }
@@ -90,7 +90,7 @@ TEST(BuilderTest, AddObjectIteratorKeyAlreadyWritten) {
   b.openObject();
   b.add(Value("foo"));
   ASSERT_FALSE(b.isClosed());
-  ASSERT_VELOCYPACK_EXCEPTION(b.add(ObjectIterator(objSlice)),
+  ASSERT_VELOCYPACK_EXCEPTION(b.add(ObjectIterator(objSlice, /*useSequentialIteration*/ false)),
                               Exception::BuilderKeyAlreadyWritten);
   ASSERT_FALSE(b.isClosed());
 }
@@ -102,7 +102,7 @@ TEST(BuilderTest, AddToObjectEmtpyStringView) {
   obj.close();
 
   ASSERT_EQ(1U, obj.slice().length());
-  ObjectIterator it(obj.slice());
+  ObjectIterator it(obj.slice(), /*useSequentialIteration*/ false);
   ASSERT_TRUE(it.valid());
   ASSERT_EQ("", it.key().stringView());
   ASSERT_EQ("", it.value().stringView());
@@ -119,7 +119,7 @@ TEST(BuilderTest, AddObjectIteratorNonObject) {
   Builder b;
   b.openArray();
   ASSERT_FALSE(b.isClosed());
-  ASSERT_VELOCYPACK_EXCEPTION(b.add(ObjectIterator(objSlice)),
+  ASSERT_VELOCYPACK_EXCEPTION(b.add(ObjectIterator(objSlice, /*useSequentialIteration*/ false)),
                               Exception::BuilderNeedOpenObject);
   ASSERT_FALSE(b.isClosed());
 }
@@ -135,7 +135,7 @@ TEST(BuilderTest, AddObjectIteratorTop) {
   Builder b;
   b.openObject();
   ASSERT_FALSE(b.isClosed());
-  b.add(ObjectIterator(objSlice));
+  b.add(ObjectIterator(objSlice, /*useSequentialIteration*/ false));
   ASSERT_FALSE(b.isClosed());
   Slice result = b.close().slice();
   ASSERT_TRUE(b.isClosed());
@@ -154,7 +154,7 @@ TEST(BuilderTest, AddObjectIteratorReference) {
   Builder b;
   b.openObject();
   ASSERT_FALSE(b.isClosed());
-  auto it = ObjectIterator(objSlice);
+  auto it = ObjectIterator(objSlice, /*useSequentialIteration*/ false);
   b.add(it);
   ASSERT_FALSE(b.isClosed());
   Slice result = b.close().slice();
@@ -176,7 +176,7 @@ TEST(BuilderTest, AddObjectIteratorSub) {
   b.add("1-something", Value("tennis"));
   b.add(Value("2-values"));
   b.openObject();
-  b.add(ObjectIterator(objSlice));
+  b.add(ObjectIterator(objSlice, /*useSequentialIteration*/ false));
   ASSERT_FALSE(b.isClosed());
   b.close();  // close one level
   b.add("3-bark", Value("qux"));
@@ -2290,7 +2290,7 @@ TEST(BuilderTest, CloneDestroyOriginal) {
 }
 
 TEST(BuilderTest, AttributeTranslations) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -2346,7 +2346,7 @@ TEST(BuilderTest, AttributeTranslations) {
 }
 
 TEST(BuilderTest, AttributeTranslationsSorted) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -2399,7 +2399,7 @@ TEST(BuilderTest, AttributeTranslationsSorted) {
 }
 
 TEST(BuilderTest, AttributeTranslationsRollbackSet) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->seal();
@@ -3011,7 +3011,7 @@ TEST(BuilderTest, KeyWritten) {
 }
 
 TEST(BuilderTest, AddWithTranslator) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);

--- a/tests/testsCollection.cpp
+++ b/tests/testsCollection.cpp
@@ -31,10 +31,10 @@
 
 #include "tests-common.h"
 
-static auto DoNothingCallback = [](Slice const&, ValueLength) -> bool {
+static auto DoNothingCallback = [](Slice, ValueLength) -> bool {
   return false;
 };
-static auto FailCallback = [](Slice const&, ValueLength) -> bool {
+static auto FailCallback = [](Slice, ValueLength) -> bool {
   EXPECT_TRUE(false);
   return false;
 };
@@ -369,7 +369,7 @@ TEST(CollectionTest, ForEachArray) {
 
   std::size_t seen = 0;
   Collection::forEach(s,
-                      [&seen](Slice const& slice, ValueLength index) -> bool {
+                      [&seen](Slice slice, ValueLength index) -> bool {
                         EXPECT_EQ(seen, index);
 
                         switch (seen) {
@@ -397,7 +397,7 @@ TEST(CollectionTest, ForEachArrayAbort) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  Collection::forEach(s, [&seen](Slice const&, ValueLength index) -> bool {
+  Collection::forEach(s, [&seen](Slice, ValueLength index) -> bool {
     EXPECT_EQ(seen, index);
 
     if (seen == 3) {
@@ -418,7 +418,7 @@ TEST(CollectionTest, IterateArrayValues) {
   Slice s(parser.start());
 
   std::size_t state = 0;
-  Collection::forEach(s, [&state](Slice const& value, ValueLength) -> bool {
+  Collection::forEach(s, [&state](Slice value, ValueLength) -> bool {
     switch (state++) {
       case 0:
         EXPECT_TRUE(value.isNumber());
@@ -516,7 +516,7 @@ TEST(CollectionTest, FilterArray) {
 
   std::size_t seen = 0;
   Builder b = Collection::filter(
-      s, [&seen](Slice const& slice, ValueLength index) -> bool {
+      s, [&seen](Slice slice, ValueLength index) -> bool {
         EXPECT_EQ(seen, index);
         EXPECT_TRUE(slice.isNumber());
 
@@ -602,7 +602,7 @@ TEST(CollectionTest, FindArrayFirst) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  Slice found = Collection::find(s, [&seen](Slice const&, ValueLength) {
+  Slice found = Collection::find(s, [&seen](Slice, ValueLength) {
     ++seen;
     return true;
   });
@@ -618,7 +618,7 @@ TEST(CollectionTest, FindArrayLast) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  Slice found = Collection::find(s, [&seen](Slice const&, ValueLength index) {
+  Slice found = Collection::find(s, [&seen](Slice, ValueLength index) {
     ++seen;
     if (index == 2) {
       return true;
@@ -665,7 +665,7 @@ TEST(CollectionTest, ContainsArrayFirst) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  ASSERT_TRUE(Collection::contains(s, [&seen](Slice const&, ValueLength) {
+  ASSERT_TRUE(Collection::contains(s, [&seen](Slice, ValueLength) {
     ++seen;
     return true;
   }));
@@ -679,7 +679,7 @@ TEST(CollectionTest, ContainsArrayLast) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  ASSERT_TRUE(Collection::contains(s, [&seen](Slice const&, ValueLength index) {
+  ASSERT_TRUE(Collection::contains(s, [&seen](Slice, ValueLength index) {
     ++seen;
     if (index == 2) {
       return true;
@@ -804,7 +804,7 @@ TEST(CollectionTest, AllArrayFirstFalse) {
 
   std::size_t seen = 0;
   ASSERT_FALSE(
-      Collection::all(s, [&seen](Slice const&, ValueLength index) -> bool {
+      Collection::all(s, [&seen](Slice, ValueLength index) -> bool {
         EXPECT_EQ(seen, index);
 
         ++seen;
@@ -822,7 +822,7 @@ TEST(CollectionTest, AllArrayLastFalse) {
 
   std::size_t seen = 0;
   ASSERT_FALSE(
-      Collection::all(s, [&seen](Slice const&, ValueLength index) -> bool {
+      Collection::all(s, [&seen](Slice, ValueLength index) -> bool {
         EXPECT_EQ(seen, index);
 
         ++seen;
@@ -843,7 +843,7 @@ TEST(CollectionTest, AllArrayTrue) {
 
   std::size_t seen = 0;
   ASSERT_TRUE(
-      Collection::all(s, [&seen](Slice const&, ValueLength index) -> bool {
+      Collection::all(s, [&seen](Slice, ValueLength index) -> bool {
         EXPECT_EQ(seen, index);
 
         ++seen;
@@ -889,7 +889,7 @@ TEST(CollectionTest, AnyArrayLastTrue) {
 
   std::size_t seen = 0;
   ASSERT_TRUE(
-      Collection::any(s, [&seen](Slice const&, ValueLength index) -> bool {
+      Collection::any(s, [&seen](Slice, ValueLength index) -> bool {
         EXPECT_EQ(seen, index);
 
         ++seen;
@@ -910,7 +910,7 @@ TEST(CollectionTest, AnyArrayFirstTrue) {
 
   std::size_t seen = 0;
   ASSERT_TRUE(
-      Collection::any(s, [&seen](Slice const&, ValueLength index) -> bool {
+      Collection::any(s, [&seen](Slice, ValueLength index) -> bool {
         EXPECT_EQ(seen, index);
 
         ++seen;
@@ -1723,22 +1723,22 @@ TEST(CollectionTest, VisitRecursiveNonCompound) {
   ASSERT_VELOCYPACK_EXCEPTION(
       Collection::visitRecursive(
           s.at(0), Collection::PreOrder,
-          [](Slice const&, Slice const&) -> bool { return true; }),
+          [](Slice, Slice) -> bool { return true; }),
       Exception::InvalidValueType);
   ASSERT_VELOCYPACK_EXCEPTION(
       Collection::visitRecursive(
           s.at(1), Collection::PreOrder,
-          [](Slice const&, Slice const&) -> bool { return true; }),
+          [](Slice, Slice) -> bool { return true; }),
       Exception::InvalidValueType);
   ASSERT_VELOCYPACK_EXCEPTION(
       Collection::visitRecursive(
           s.at(2), Collection::PreOrder,
-          [](Slice const&, Slice const&) -> bool { return true; }),
+          [](Slice, Slice) -> bool { return true; }),
       Exception::InvalidValueType);
   ASSERT_VELOCYPACK_EXCEPTION(
       Collection::visitRecursive(
           s.at(3), Collection::PreOrder,
-          [](Slice const&, Slice const&) -> bool { return true; }),
+          [](Slice, Slice) -> bool { return true; }),
       Exception::InvalidValueType);
 }
 
@@ -1752,7 +1752,7 @@ TEST(CollectionTest, VisitRecursiveArrayPreOrderAbort) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PreOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_TRUE(key.isNone());
         switch (seen) {
           case 0:
@@ -1781,7 +1781,7 @@ TEST(CollectionTest, VisitRecursiveArrayPostOrderAbort) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PostOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_TRUE(key.isNone());
         switch (seen) {
           case 0:
@@ -1814,7 +1814,7 @@ TEST(CollectionTest, VisitRecursiveObjectPreOrderAbort) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PreOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_FALSE(key.isNone());
         switch (seen) {
           case 0:
@@ -1845,7 +1845,7 @@ TEST(CollectionTest, VisitRecursiveObjectPostOrderAbort) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PostOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_FALSE(key.isNone());
         switch (seen) {
           case 0:
@@ -1877,7 +1877,7 @@ TEST(CollectionTest, VisitRecursiveArrayPreOrder) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PreOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_TRUE(key.isNone());
         switch (seen) {
           case 0:
@@ -1931,7 +1931,7 @@ TEST(CollectionTest, VisitRecursiveArrayPostOrder) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PostOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_TRUE(key.isNone());
         switch (seen) {
           case 0:
@@ -1987,7 +1987,7 @@ TEST(CollectionTest, VisitRecursiveObjectPreOrder) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PreOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_FALSE(key.isNone());
         switch (seen) {
           case 0:
@@ -2043,7 +2043,7 @@ TEST(CollectionTest, VisitRecursiveObjectPostOrder) {
   int seen = 0;
   Collection::visitRecursive(
       s, Collection::PostOrder,
-      [&seen](Slice const& key, Slice const& value) -> bool {
+      [&seen](Slice key, Slice value) -> bool {
         EXPECT_FALSE(key.isNone());
         switch (seen) {
           case 0:

--- a/tests/testsDumper.cpp
+++ b/tests/testsDumper.cpp
@@ -1699,7 +1699,7 @@ TEST(StringDumperTest, BCDNeg) {
 }
 
 TEST(StringDumperTest, AttributeTranslationsNotSet) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
   // intentionally don't add any translations
   translator->seal();
 
@@ -1721,7 +1721,7 @@ TEST(StringDumperTest, AttributeTranslationsNotSet) {
 }
 
 TEST(StringDumperTest, AttributeTranslations) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -1756,7 +1756,7 @@ TEST(StringDumperTest, AttributeTranslations) {
 }
 
 TEST(StringDumperTest, AttributeTranslationsInSubObjects) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);

--- a/tests/testsIterator.cpp
+++ b/tests/testsIterator.cpp
@@ -448,7 +448,7 @@ TEST(IteratorTest, IterateNonObject1) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s), Exception::InvalidValueType);
+  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s, /*useSequentialIteration*/ true), Exception::InvalidValueType);
 }
 
 TEST(IteratorTest, IterateNonObject2) {
@@ -457,7 +457,7 @@ TEST(IteratorTest, IterateNonObject2) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s), Exception::InvalidValueType);
+  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s, /*useSequentialIteration*/ true), Exception::InvalidValueType);
 }
 
 TEST(IteratorTest, IterateNonObject3) {
@@ -466,7 +466,7 @@ TEST(IteratorTest, IterateNonObject3) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s), Exception::InvalidValueType);
+  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s, /*useSequentialIteration*/ true), Exception::InvalidValueType);
 }
 
 TEST(IteratorTest, IterateNonObject4) {
@@ -475,7 +475,7 @@ TEST(IteratorTest, IterateNonObject4) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s), Exception::InvalidValueType);
+  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s, /*useSequentialIteration*/ true), Exception::InvalidValueType);
 }
 
 TEST(IteratorTest, IterateNonObject5) {
@@ -484,7 +484,7 @@ TEST(IteratorTest, IterateNonObject5) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s), Exception::InvalidValueType);
+  ASSERT_VELOCYPACK_EXCEPTION(ObjectIterator(s, /*useSequentialIteration*/ true), Exception::InvalidValueType);
 }
 
 TEST(IteratorTest, IterateObjectEmpty) {
@@ -494,7 +494,7 @@ TEST(IteratorTest, IterateObjectEmpty) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ true);
   ASSERT_FALSE(it.valid());
 
   ASSERT_VELOCYPACK_EXCEPTION(std::ignore = it.key(),
@@ -515,7 +515,7 @@ TEST(IteratorTest, IterateObject) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
 
   ASSERT_TRUE(it.valid());
   Slice key = it.key();
@@ -649,7 +649,7 @@ TEST(IteratorTest, IterateObjectCompact) {
 
   ASSERT_EQ(0x14, s.head());
 
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
 
   ASSERT_TRUE(it.valid());
   Slice key = it.key();
@@ -739,7 +739,7 @@ TEST(IteratorTest, IterateObjectKeys) {
   Slice s(parser.start());
 
   std::size_t state = 0;
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     Slice key(it.key());
@@ -792,7 +792,7 @@ TEST(IteratorTest, IterateObjectKeysCompact) {
   ASSERT_EQ(0x14, s.head());
 
   std::size_t state = 0;
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     Slice key(it.key());
@@ -840,7 +840,7 @@ TEST(IteratorTest, IterateObjectValues) {
   Slice s(parser.start());
 
   std::vector<std::string> seenKeys;
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     seenKeys.emplace_back(it.key().copyString());
@@ -870,7 +870,7 @@ TEST(IteratorTest, IterateObjectValuesCompact) {
   ASSERT_EQ(0x14, s.head());
 
   std::vector<std::string> seenKeys;
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
 
   while (it.valid()) {
     seenKeys.emplace_back(it.key().copyString());
@@ -924,7 +924,7 @@ TEST(IteratorTest, ArrayIteratorRangeBasedForConst) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  for (auto const it : ArrayIterator(s)) {
+  for (auto it : ArrayIterator(s)) {
     ASSERT_TRUE(it.isNumber());
     ASSERT_EQ(seen + 1, it.getUInt());
     ++seen;
@@ -940,7 +940,7 @@ TEST(IteratorTest, ArrayIteratorRangeBasedForConstRef) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  for (auto const& it : ArrayIterator(s)) {
+  for (auto it : ArrayIterator(s)) {
     ASSERT_TRUE(it.isNumber());
     ASSERT_EQ(seen + 1, it.getUInt());
     ++seen;
@@ -976,12 +976,10 @@ TEST(IteratorTest, ObjectIteratorRangeBasedForEmpty) {
   parser.parse(value);
   Slice s(parser.start());
 
-  std::size_t seen = 0;
-  for (auto it : ObjectIterator(s)) {
+  for (auto it : ObjectIterator(s, /*useSequentialIteration*/ true)) {
     ASSERT_TRUE(false);
     ASSERT_FALSE(it.value.isNumber());  // only in here to please the compiler
   }
-  ASSERT_EQ(0UL, seen);
 }
 
 TEST(IteratorTest, ObjectIteratorRangeBasedFor) {
@@ -992,7 +990,7 @@ TEST(IteratorTest, ObjectIteratorRangeBasedFor) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  for (auto it : ObjectIterator(s)) {
+  for (auto it : ObjectIterator(s, /*useSequentialIteration*/ false)) {
     ASSERT_TRUE(it.key.isString());
     if (seen == 0) {
       ASSERT_EQ("1foo", it.key.copyString());
@@ -1016,7 +1014,7 @@ TEST(IteratorTest, ObjectIteratorRangeBasedForConst) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  for (auto const it : ObjectIterator(s)) {
+  for (auto it : ObjectIterator(s, /*useSequentialIteration*/ false)) {
     ASSERT_TRUE(it.key.isString());
     if (seen == 0) {
       ASSERT_EQ("1foo", it.key.copyString());
@@ -1040,7 +1038,7 @@ TEST(IteratorTest, ObjectIteratorRangeBasedForConstRef) {
   Slice s(parser.start());
 
   std::size_t seen = 0;
-  for (auto const& it : ObjectIterator(s)) {
+  for (auto it : ObjectIterator(s, /*useSequentialIteration*/ false)) {
     ASSERT_TRUE(it.key.isString());
     if (seen == 0) {
       ASSERT_EQ("1foo", it.key.copyString());
@@ -1069,7 +1067,7 @@ TEST(IteratorTest, ObjectIteratorRangeBasedForCompact) {
   ASSERT_EQ(0x14, s.head());
 
   std::size_t seen = 0;
-  for (auto it : ObjectIterator(s)) {
+  for (auto it : ObjectIterator(s, /*useSequentialIteration*/ false)) {
     ASSERT_TRUE(it.key.isString());
     if (seen == 0) {
       ASSERT_EQ("1foo", it.key.copyString());
@@ -1086,7 +1084,7 @@ TEST(IteratorTest, ObjectIteratorRangeBasedForCompact) {
 }
 
 TEST(IteratorTest, ObjectIteratorTranslations) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -1107,7 +1105,7 @@ TEST(IteratorTest, ObjectIteratorTranslations) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
   ASSERT_EQ(6UL, it.size());
 
   while (it.valid()) {
@@ -1196,7 +1194,7 @@ TEST(IteratorTest, ObjectIteratorToStream) {
   parser.parse(value);
   Slice s(parser.start());
 
-  ObjectIterator it(s);
+  ObjectIterator it(s, /*useSequentialIteration*/ false);
 
   {
     std::ostringstream result;

--- a/tests/testsSlice.cpp
+++ b/tests/testsSlice.cpp
@@ -2936,7 +2936,7 @@ TEST(SliceTest, GetNumericValueWrongSource) {
 }
 
 TEST(SliceTest, Translate) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -2990,7 +2990,7 @@ TEST(SliceTest, Translate) {
 }
 
 TEST(SliceTest, TranslateSingleMember) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->seal();
@@ -3020,7 +3020,7 @@ TEST(SliceTest, TranslateSingleMember) {
 }
 
 TEST(SliceTest, Translations) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -3078,7 +3078,7 @@ TEST(SliceTest, Translations) {
 }
 
 TEST(SliceTest, TranslationsSingleMemberObject) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->seal();
@@ -3104,7 +3104,7 @@ TEST(SliceTest, TranslationsSingleMemberObject) {
 }
 
 TEST(SliceTest, TranslationsSubObjects) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -3163,7 +3163,7 @@ TEST(SliceTest, TranslationsSubObjects) {
 }
 
 TEST(SliceTest, TranslatedObjectWithoutTranslator) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -3202,7 +3202,7 @@ TEST(SliceTest, TranslatedObjectWithoutTranslator) {
 }
 
 TEST(SliceTest, TranslatedWithCompactNotation) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->add("bar", 2);
@@ -3238,7 +3238,7 @@ TEST(SliceTest, TranslatedWithCompactNotation) {
 }
 
 TEST(SliceTest, TranslatedInvalidKey) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("foo", 1);
   translator->seal();
@@ -3372,7 +3372,7 @@ TEST(SliceTest, Reassign) {
 }
 
 TEST(SliceTest, TranslateInObjectIterator) {
-  std::unique_ptr<AttributeTranslator> translator(new AttributeTranslator);
+  auto translator = std::make_unique<AttributeTranslator>();
 
   translator->add("_key", 1);
   translator->seal();
@@ -3385,7 +3385,7 @@ TEST(SliceTest, TranslateInObjectIterator) {
   b.close();
 
   Slice s = b.slice();
-  for (auto p : ObjectIterator(s)) {
+  for (auto p : ObjectIterator(s, /*useSequentialIteration*/ true)) {
     Slice k = p.key;
     ASSERT_TRUE(k.isString());
   }


### PR DESCRIPTION
the second argument of the `ObjectIterator` ctor determines whether the attributes in the object should be iterated in sorted order (sorted by attribute names) or be iterated in storage order.
that parameter previously defaulted to `false`, meaning that sorted iteration was used by default. sorted iteration may come with a performance overhead, so it is better to make the choice explicit. this change removes the default value for the parameter, so the user now must explicitly set the iteration order to either
- `false`: iterate in sorted order (same as default value before)
- `true`: iterate in storage order