### PR TITLE
add ValueString2Parts

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,6 +1,7 @@
 name: velocypack-test
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:

--- a/include/velocypack/Builder.h
+++ b/include/velocypack/Builder.h
@@ -393,6 +393,11 @@ class Builder {
                                      ValuePair const& sub) {
     return addInternal<ValuePair>(std::string_view(attrName, attrLength), sub);
   }
+  
+  // Add a subvalue into an object from a ValueString2Parts:
+  inline uint8_t* add(std::string_view attrName, ValueString2Parts const& sub) {
+    return addInternal<ValueString2Parts>(attrName, sub);
+  }
 
   // Add a subvalue into an object from a Serializable:
   inline uint8_t* add(std::string_view attrName, Serialize const& sub) {
@@ -419,6 +424,11 @@ class Builder {
   // Add a subvalue into an array from a ValuePair:
   inline uint8_t* add(ValuePair const& sub) {
     return addInternal<ValuePair>(sub);
+  }
+  
+  // Add a subvalue into an array from a ValueString2Parts:
+  inline uint8_t* add(ValueString2Parts const& sub) {
+    return addInternal<ValueString2Parts>(sub);
   }
 
   // Add a subvalue into an array from a Serializable:
@@ -561,6 +571,12 @@ class Builder {
     add(attrName, sub);
     return *this;
   }
+  
+  // Syntactic sugar for add:
+  Builder& operator()(std::string_view attrName, ValueString2Parts const& sub) {
+    add(attrName, sub);
+    return *this;
+  }
 
   // Syntactic sugar for add:
   Builder& operator()(std::string_view attrName, Slice sub) {
@@ -576,6 +592,12 @@ class Builder {
 
   // Syntactic sugar for add:
   Builder& operator()(ValuePair const& sub) {
+    add(sub);
+    return *this;
+  }
+  
+  // Syntactic sugar for add:
+  Builder& operator()(ValueString2Parts const& sub) {
     add(sub);
     return *this;
   }
@@ -930,6 +952,8 @@ class Builder {
   uint8_t* set(Value const& item);
 
   uint8_t* set(ValuePair const& pair);
+  
+  uint8_t* set(ValueString2Parts const& parts);
 
   uint8_t* set(Slice const& item);
 

--- a/include/velocypack/Builder.h
+++ b/include/velocypack/Builder.h
@@ -393,10 +393,10 @@ class Builder {
                                      ValuePair const& sub) {
     return addInternal<ValuePair>(std::string_view(attrName, attrLength), sub);
   }
-  
-  // Add a subvalue into an object from a ValueString2Parts:
-  inline uint8_t* add(std::string_view attrName, ValueString2Parts const& sub) {
-    return addInternal<ValueString2Parts>(attrName, sub);
+
+  // Add a subvalue into an object from a IStringFromParts:
+  inline uint8_t* add(std::string_view attrName, IStringFromParts const& sub) {
+    return addInternal<IStringFromParts>(attrName, sub);
   }
 
   // Add a subvalue into an object from a Serializable:
@@ -425,10 +425,10 @@ class Builder {
   inline uint8_t* add(ValuePair const& sub) {
     return addInternal<ValuePair>(sub);
   }
-  
+
   // Add a subvalue into an array from a ValueString2Parts:
-  inline uint8_t* add(ValueString2Parts const& sub) {
-    return addInternal<ValueString2Parts>(sub);
+  inline uint8_t* add(IStringFromParts const& sub) {
+    return addInternal<IStringFromParts>(sub);
   }
 
   // Add a subvalue into an array from a Serializable:
@@ -571,9 +571,9 @@ class Builder {
     add(attrName, sub);
     return *this;
   }
-  
+
   // Syntactic sugar for add:
-  Builder& operator()(std::string_view attrName, ValueString2Parts const& sub) {
+  Builder& operator()(std::string_view attrName, IStringFromParts const& sub) {
     add(attrName, sub);
     return *this;
   }
@@ -595,9 +595,9 @@ class Builder {
     add(sub);
     return *this;
   }
-  
+
   // Syntactic sugar for add:
-  Builder& operator()(ValueString2Parts const& sub) {
+  Builder& operator()(IStringFromParts const& sub) {
     add(sub);
     return *this;
   }
@@ -952,8 +952,8 @@ class Builder {
   uint8_t* set(Value const& item);
 
   uint8_t* set(ValuePair const& pair);
-  
-  uint8_t* set(ValueString2Parts const& parts);
+
+  uint8_t* set(IStringFromParts const& parts);
 
   uint8_t* set(Slice const& item);
 

--- a/include/velocypack/Value.h
+++ b/include/velocypack/Value.h
@@ -40,20 +40,20 @@ class Value {
 
  public:
   enum class CType {
-    None = 0,
-    Bool = 1,
-    Double = 2,
-    Int64 = 3,
-    UInt64 = 4,
-    String = 5,
-    CharPtr = 6,
-    VoidPtr = 7,
-    StringView = 8
+    None,
+    Bool,
+    Double,
+    Int64,
+    UInt64,
+    String,
+    CharPtr,
+    VoidPtr,
+    StringView,
   };
 
  private:
   ValueType const _valueType;
-  CType const _cType;  // denotes variant used, 0: none
+  CType const _cType;
 
   union ValueUnion {
     constexpr explicit ValueUnion(bool b) noexcept : b(b) {}
@@ -66,14 +66,14 @@ class Value {
     constexpr explicit ValueUnion(std::string_view const* sv) noexcept
         : sv(sv) {}
 
-    bool b;                      // 1: bool
-    double d;                    // 2: double
-    int64_t i;                   // 3: int64_t
-    uint64_t u;                  // 4: uint64_t
-    std::string const* s;        // 5: std::string
-    char const* c;               // 6: char const*
-    void const* e;               // 7: external
-    std::string_view const* sv;  // 8: std::string_view
+    bool b;
+    double d;
+    int64_t i;
+    uint64_t u;
+    std::string const* s;
+    char const* c;
+    void const* e;
+    std::string_view const* sv;
   } const _value;
 
  public:
@@ -219,7 +219,33 @@ class ValuePair {
   bool isString() const noexcept { return _type == ValueType::String; }
 };
 
+class ValueString2Parts {
+  friend class Builder;
+
+ private:
+  std::string_view const* sv1;
+  std::string_view const* sv2;
+
+ public:
+  constexpr explicit ValueString2Parts(std::string_view const& s1,
+                                       std::string_view const& s2) noexcept
+      : sv1(&s1), sv2(&s2) {}
+
+  constexpr size_t getSize() const noexcept {
+    return sv1->size() + sv2->size();
+  }
+  
+  constexpr std::string_view const* getFirst() const noexcept {
+    return sv1;
+  }
+  
+  constexpr std::string_view const* getSecond() const noexcept {
+    return sv2;
+  }
+};
+
 }  // namespace arangodb::velocypack
 
 using VPackValue = arangodb::velocypack::Value;
 using VPackValuePair = arangodb::velocypack::ValuePair;
+using VPackValueString2Parts = arangodb::velocypack::ValueString2Parts;

--- a/include/velocypack/Value.h
+++ b/include/velocypack/Value.h
@@ -227,8 +227,8 @@ class ValueString2Parts {
   std::string_view sv2;
 
  public:
-  constexpr explicit ValueString2Parts(std::string_view const& s1,
-                                       std::string_view const& s2) noexcept
+  constexpr ValueString2Parts(std::string_view s1,
+                              std::string_view s2) noexcept
       : sv1(s1), sv2(s2) {}
 
   constexpr size_t getSize() const noexcept {

--- a/include/velocypack/Value.h
+++ b/include/velocypack/Value.h
@@ -219,33 +219,16 @@ class ValuePair {
   bool isString() const noexcept { return _type == ValueType::String; }
 };
 
-class ValueString2Parts {
-  friend class Builder;
+// TODO(MBkkt) Make it concept to avoid size() + 2 virtual calls
+struct IStringFromParts {
+  virtual std::size_t size() const = 0;
 
- private:
-  std::string_view sv1;
-  std::string_view sv2;
+  virtual std::size_t length() const = 0;
 
- public:
-  constexpr ValueString2Parts(std::string_view s1,
-                              std::string_view s2) noexcept
-      : sv1(s1), sv2(s2) {}
-
-  constexpr size_t getSize() const noexcept {
-    return sv1.size() + sv2.size();
-  }
-  
-  constexpr std::string_view const& getFirst() const noexcept {
-    return sv1;
-  }
-  
-  constexpr std::string_view const& getSecond() const noexcept {
-    return sv2;
-  }
+  virtual std::string_view operator()(std::size_t index) const = 0;
 };
 
 }  // namespace arangodb::velocypack
 
 using VPackValue = arangodb::velocypack::Value;
 using VPackValuePair = arangodb::velocypack::ValuePair;
-using VPackValueString2Parts = arangodb::velocypack::ValueString2Parts;

--- a/include/velocypack/Value.h
+++ b/include/velocypack/Value.h
@@ -223,23 +223,23 @@ class ValueString2Parts {
   friend class Builder;
 
  private:
-  std::string_view const* sv1;
-  std::string_view const* sv2;
+  std::string_view sv1;
+  std::string_view sv2;
 
  public:
   constexpr explicit ValueString2Parts(std::string_view const& s1,
                                        std::string_view const& s2) noexcept
-      : sv1(&s1), sv2(&s2) {}
+      : sv1(s1), sv2(s2) {}
 
   constexpr size_t getSize() const noexcept {
-    return sv1->size() + sv2->size();
+    return sv1.size() + sv2.size();
   }
   
-  constexpr std::string_view const* getFirst() const noexcept {
+  constexpr std::string_view const& getFirst() const noexcept {
     return sv1;
   }
   
-  constexpr std::string_view const* getSecond() const noexcept {
+  constexpr std::string_view const& getSecond() const noexcept {
     return sv2;
   }
 };

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -1242,31 +1242,27 @@ uint8_t* Builder::set(ValuePair const& pair) {
                   "ValueType::Custom are valid for ValuePair argument");
 }
 
-uint8_t* Builder::set(ValueString2Parts const& parts) {
+uint8_t* Builder::set(IStringFromParts const& parts) {
   // This method builds a single VPack String item composed of the 2 parts.
   auto const oldPos = _pos;
-  
+
   checkKeyHasValidType(true);
 
-  uint64_t size = parts.getSize();
-  if (size > 126) {
+  uint64_t length = parts.length();
+  if (length > 126) {
     // long string
-    reserve(1 + 8 + size);
+    reserve(1 + 8 + length);
     appendByteUnchecked(0xbf);
-    appendLengthUnchecked<8>(size);
+    appendLengthUnchecked<8>(length);
   } else {
     // short string
-    reserve(1 + size);
-    appendByteUnchecked(static_cast<uint8_t>(0x40 + size));
+    reserve(1 + length);
+    appendByteUnchecked(static_cast<uint8_t>(0x40 + length));
   }
-  if (size != 0) {
-    VELOCYPACK_ASSERT(size == parts.getFirst().size() + parts.getSecond().size());
-    // first part
-    std::memcpy(_start + _pos, parts.getFirst().data(), checkOverflow(parts.getFirst().size()));
-    advance(parts.getFirst().size());
-    // second part
-    std::memcpy(_start + _pos, parts.getSecond().data(), checkOverflow(parts.getSecond().size()));
-    advance(parts.getSecond().size());
+  for (std::size_t index = 0, size = parts.size(); index != size; ++index) {
+    auto part = parts(index);
+    std::memcpy(_start + _pos, part.data(), checkOverflow(part.size()));
+    advance(part.size());
   }
   return _start + oldPos;
 }

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -1261,8 +1261,10 @@ uint8_t* Builder::set(IStringFromParts const& parts) {
   }
   for (std::size_t index = 0, size = parts.size(); index != size; ++index) {
     auto part = parts(index);
-    std::memcpy(_start + _pos, part.data(), checkOverflow(part.size()));
-    advance(part.size());
+    if (part.size() != 0) {
+      std::memcpy(_start + _pos, part.data(), checkOverflow(part.size()));
+      advance(part.size());
+    }
   }
   return _start + oldPos;
 }

--- a/src/Builder.cpp
+++ b/src/Builder.cpp
@@ -1260,18 +1260,13 @@ uint8_t* Builder::set(ValueString2Parts const& parts) {
     appendByteUnchecked(static_cast<uint8_t>(0x40 + size));
   }
   if (size != 0) {
+    VELOCYPACK_ASSERT(size == parts.getFirst().size() + parts.getSecond().size());
     // first part
-    std::string_view const* sv = parts.getFirst();
-    VELOCYPACK_ASSERT(sv != nullptr);
-    std::memcpy(_start + _pos, sv->data(), checkOverflow(sv->size()));
-    advance(sv->size());
+    std::memcpy(_start + _pos, parts.getFirst().data(), checkOverflow(parts.getFirst().size()));
+    advance(parts.getFirst().size());
     // second part
-    sv = parts.getSecond();
-    VELOCYPACK_ASSERT(sv != nullptr);
-    std::memcpy(_start + _pos, sv->data(), checkOverflow(sv->size()));
-    advance(sv->size());
-    
-    VELOCYPACK_ASSERT(size == parts.getFirst()->size() + parts.getSecond()->size());
+    std::memcpy(_start + _pos, parts.getSecond().data(), checkOverflow(parts.getSecond().size()));
+    advance(parts.getSecond().size());
   }
   return _start + oldPos;
 }

--- a/tests/testsAliases.cpp
+++ b/tests/testsAliases.cpp
@@ -51,6 +51,8 @@ using VPackStringSink = arangodb::velocypack::StringSink;
 using VPackStringStreamSink = arangodb::velocypack::StringStreamSink;
 using VPackValue = arangodb::velocypack::Value;
 using VPackValueLength = arangodb::velocypack::ValueLength;
+using VPackValuePair = arangodb::velocypack::ValuePair;
+using VPackValueString2Parts = arangodb::velocypack::ValueString2Parts;
 using VPackValueType = arangodb::velocypack::ValueType;
 using VPackVersion = arangodb::velocypack::Version;
 

--- a/tests/testsAliases.cpp
+++ b/tests/testsAliases.cpp
@@ -52,7 +52,6 @@ using VPackStringStreamSink = arangodb::velocypack::StringStreamSink;
 using VPackValue = arangodb::velocypack::Value;
 using VPackValueLength = arangodb::velocypack::ValueLength;
 using VPackValuePair = arangodb::velocypack::ValuePair;
-using VPackValueString2Parts = arangodb::velocypack::ValueString2Parts;
 using VPackValueType = arangodb::velocypack::ValueType;
 using VPackVersion = arangodb::velocypack::Version;
 

--- a/tests/testsBuilder.cpp
+++ b/tests/testsBuilder.cpp
@@ -1752,6 +1752,89 @@ TEST(BuilderTest, StringView) {
   ASSERT_EQ(value, c);
 }
 
+TEST(BuilderTest, String2Parts) {
+  std::string_view const value1("der fuxx ging in den wald und aß pilze");
+  std::string_view const value2("der hans, der hans, der kanns");
+  std::string const combined = std::string(value1) + std::string(value2);
+  Builder b;
+  b.add(ValueString2Parts(value1, value2));
+
+  Slice slice = Slice(b.start());
+  ASSERT_TRUE(slice.isString());
+
+  ValueLength len;
+  char const* s = slice.getString(len);
+  ASSERT_EQ(combined.size(), len);
+  ASSERT_EQ(0, strncmp(s, combined.data(), combined.size()));
+
+  std::string_view c = slice.stringView();
+  ASSERT_EQ(combined.size(), c.size());
+  ASSERT_EQ(combined, c);
+}
+
+TEST(BuilderTest, String2PartsEmpty) {
+  std::string_view const value1;
+  std::string_view const value2;
+  Builder b;
+  b.add(ValueString2Parts(value1, value2));
+
+  Slice slice = Slice(b.start());
+  ASSERT_TRUE(slice.isString());
+
+  ValueLength len;
+  char const* s = slice.getString(len);
+  ASSERT_EQ(0, strncmp(s, "", 0));
+  ASSERT_EQ(0, len);
+
+  std::string_view c = slice.stringView();
+  ASSERT_EQ(0, c.size());
+}
+
+TEST(BuilderTest, String2PartsLong) {
+  std::string_view const value1("der fuxx ging in den wald und aß pilze und findets ziemlich gut. ist halt ein fuxx, das ist so");
+  std::string_view const value2("der hans, der hans, der kanns, und der hund, der steht im wald und sieht den fuxx und findets auch sehr gut");
+  std::string const combined = std::string(value1) + std::string(value2);
+  // long string offset
+  ASSERT_GT(combined.size(), 128);
+  Builder b;
+  b.add(ValueString2Parts(value1, value2));
+
+  Slice slice = Slice(b.start());
+  ASSERT_TRUE(slice.isString());
+
+  ValueLength len;
+  char const* s = slice.getString(len);
+  ASSERT_EQ(combined.size(), len);
+  ASSERT_EQ(0, strncmp(s, combined.data(), combined.size()));
+
+  std::string_view c = slice.stringView();
+  ASSERT_EQ(combined.size(), c.size());
+  ASSERT_EQ(combined, c);
+}
+
+TEST(BuilderTest, String2PartsInObject) {
+  std::string_view const value1("der fuxx ging in den wald und aß pilze");
+  std::string_view const value2("der hans, der hans, der kanns");
+  std::string const combined1 = std::string(value1) + std::string(value2);
+  std::string const combined2 = std::string(value2) + std::string(value1);
+  Builder b;
+  b.openObject();
+  b.add("foo", ValueString2Parts(value2, value1));
+  b.add("bar", ValueString2Parts(value1, value2));
+  b.close();
+
+  Slice slice = Slice(b.start());
+  ASSERT_TRUE(slice.isObject());
+
+  std::string_view c = slice.get("foo").stringView();
+  ASSERT_EQ(combined2.size(), c.size());
+  ASSERT_EQ(combined2, c);
+  
+  c = slice.get("bar").stringView();
+  ASSERT_EQ(combined1.size(), c.size());
+  ASSERT_EQ(combined1, c);
+}
+
 TEST(BuilderTest, BinaryViaValuePair) {
   uint8_t binaryStuff[] = {0x02, 0x03, 0x05, 0x08, 0x0d};
 
@@ -3757,7 +3840,7 @@ TEST(BuilderTest, syntacticSugar) {
 
   b(Value(ValueType::Object))("b", Value(12))("a", Value(true))(
       "l", Value(ValueType::Array))(Value(1))(Value(2))(Value(3))()(
-      "name", Value("Gustav"))();
+      "name", Value("Gustav"))("type", ValueString2Parts("the", "machine"))();
 
   ASSERT_FALSE(b.isOpenObject());
   ASSERT_TRUE(b.slice().get("b").isInteger());
@@ -3767,7 +3850,8 @@ TEST(BuilderTest, syntacticSugar) {
   ASSERT_TRUE(b.slice().get("l").isArray());
   ASSERT_EQ(3, b.slice().get("l").length());
   ASSERT_TRUE(b.slice().get("name").isString());
-  ASSERT_EQ("Gustav", b.slice().get("name").copyString());
+  ASSERT_EQ("Gustav", b.slice().get("name").stringView());
+  ASSERT_EQ("themachine", b.slice().get("type").stringView());
 }
 
 int main(int argc, char* argv[]) {

--- a/tests/testsBuilder.cpp
+++ b/tests/testsBuilder.cpp
@@ -1772,6 +1772,26 @@ TEST(BuilderTest, String2Parts) {
   ASSERT_EQ(combined, c);
 }
 
+TEST(BuilderTest, String2PartsFromChars) {
+  char const* value1("der fuxx ging in den wald und aß pilze");
+  char const* value2("der hans, der hans, der kanns");
+  std::string const combined = std::string(value1) + std::string(value2);
+  Builder b;
+  b.add(ValueString2Parts(value1, value2));
+
+  Slice slice = Slice(b.start());
+  ASSERT_TRUE(slice.isString());
+
+  ValueLength len;
+  char const* s = slice.getString(len);
+  ASSERT_EQ(combined.size(), len);
+  ASSERT_EQ(0, strncmp(s, combined.data(), combined.size()));
+
+  std::string_view c = slice.stringView();
+  ASSERT_EQ(combined.size(), c.size());
+  ASSERT_EQ(combined, c);
+}
+
 TEST(BuilderTest, String2PartsEmpty) {
   std::string_view const value1;
   std::string_view const value2;


### PR DESCRIPTION
Add `ValueString2Parts` class to allow adding String values that should be concatened from 2 substrings, e.g.
```
Builder b;
b.add(ValueString2Parts("foo", "bar"));
```
This concatenates `"foo"` and `"bar"` into a single velocypack String value, without needing to create a temporary std::string first.

For sure the implementation is not as elegant as possible, but it works fine.