### PR TITLE
Fix warning when compile velocypack

### DIFF
--- a/src/SharedSlice.cpp
+++ b/src/SharedSlice.cpp
@@ -301,7 +301,7 @@ ValueLength SharedSlice::getStringLength() const {
 std::string SharedSlice::copyString() const { return slice().copyString(); }
 
 [[deprecated("use stringView")]] StringRef SharedSlice::stringRef() const {
-  return slice().stringRef();
+  return slice().stringView();
 }
 
 std::string_view SharedSlice::stringView() const {


### PR DESCRIPTION
In general I think better and not difficult to remove stringRef at all

```
07:49:05 /home/jenkins/workspace/iresearch-release_aarch64/external/velocypack/src/SharedSlice.cpp: In member function ‘arangodb::velocypack::StringRef arangodb::velocypack::SharedSlice::stringRef() const’:
07:49:05 /home/jenkins/workspace/iresearch-release_aarch64/external/velocypack/src/SharedSlice.cpp:304:28: warning: ‘arangodb::velocypack::StringRef arangodb::velocypack::Slice::stringRef() const’ is deprecated: use stringView [-Wdeprecated-declarations]
07:49:05   304 |   return slice().stringRef();
07:49:05       |                            ^
07:49:05 In file included from /home/jenkins/workspace/iresearch-release_aarch64/external/velocypack/include/velocypack/SharedSlice.h:27,
07:49:05                  from /home/jenkins/workspace/iresearch-release_aarch64/external/velocypack/src/SharedSlice.cpp:24:
07:49:05 /home/jenkins/workspace/iresearch-release_aarch64/external/velocypack/include/velocypack/Slice.h:872:46: note: declared here
07:49:05   872 |   [[deprecated("use stringView")]] StringRef stringRef() const {
07:49:05       |                                              ^~~~~~~~~
```