### PR TITLE
Fix JSON dumping of large numbers

### DIFF
--- a/src/Dumper.cpp
+++ b/src/Dumper.cpp
@@ -217,6 +217,9 @@ void Dumper::appendDouble(double v) {
   char temp[24];
   int len = fpconv_dtoa(v, &temp[0]);
   _sink->append(&temp[0], static_cast<ValueLength>(len));
+  if (fabs(v) < ldexpl(1.0, 53)) {
+    return;
+  }
   for (size_t i = 0; i < len; ++i) {
     if (temp[i] == '.') {
       return;

--- a/src/Dumper.cpp
+++ b/src/Dumper.cpp
@@ -54,8 +54,7 @@ void Dumper::dump(Slice slice) {
   dumpValue(slice);
 }
 
-/*static*/ void Dumper::dump(Slice slice, Sink* sink,
-                             Options const* options) {
+/*static*/ void Dumper::dump(Slice slice, Sink* sink, Options const* options) {
   Dumper dumper(sink, options);
   dumper.dump(slice);
 }
@@ -65,8 +64,7 @@ void Dumper::dump(Slice slice) {
   dump(*slice, sink, options);
 }
 
-/*static*/ std::string Dumper::toString(Slice slice,
-                                        Options const* options) {
+/*static*/ std::string Dumper::toString(Slice slice, Options const* options) {
   std::string buffer;
   StringSink sink(&buffer);
   dump(slice, &sink, options);
@@ -219,6 +217,7 @@ void Dumper::appendDouble(double v) {
   char temp[24];
   int len = fpconv_dtoa(v, &temp[0]);
   _sink->append(&temp[0], static_cast<ValueLength>(len));
+  _sink->append(".0", 2);
 }
 
 void Dumper::dumpUnicodeCharacter(uint16_t value) {
@@ -545,8 +544,7 @@ void Dumper::dumpValue(Slice slice, Slice const* base) {
         base = &slice;
       }
 
-      Slice external(
-          reinterpret_cast<uint8_t const*>(slice.getExternal()));
+      Slice external(reinterpret_cast<uint8_t const*>(slice.getExternal()));
       dumpValue(external, base);
       break;
     }
@@ -624,8 +622,8 @@ void Dumper::handleUnsupportedType(Slice slice) {
     return;
   } else if (options->unsupportedTypeBehavior ==
              Options::ConvertUnsupportedType) {
-    _sink->append(std::string("\"(non-representable type ") +
-                  slice.typeName() + ")\"");
+    _sink->append(std::string("\"(non-representable type ") + slice.typeName() +
+                  ")\"");
     return;
   }
 

--- a/src/Dumper.cpp
+++ b/src/Dumper.cpp
@@ -217,6 +217,11 @@ void Dumper::appendDouble(double v) {
   char temp[24];
   int len = fpconv_dtoa(v, &temp[0]);
   _sink->append(&temp[0], static_cast<ValueLength>(len));
+  for (size_t i = 0; i < len; ++i) {
+    if (temp[i] == '.') {
+      return;
+    }
+  }
   _sink->append(".0", 2);
 }
 

--- a/src/Dumper.cpp
+++ b/src/Dumper.cpp
@@ -221,7 +221,7 @@ void Dumper::appendDouble(double v) {
     return;
   }
   for (size_t i = 0; i < len; ++i) {
-    if (temp[i] == '.') {
+    if (temp[i] == '.' || temp[i] == 'e' || temp[i] == 'E') {
       return;
     }
   }

--- a/tests/testsDumper.cpp
+++ b/tests/testsDumper.cpp
@@ -490,8 +490,9 @@ TEST(StringDumperTest, SuppressControlChars) {
 
 TEST(StringDumperTest, EscapeControlChars) {
   Builder b;
-  b.add(Value(
-      "Before\nAfter\r\t\v\f\b\x01\x02/\u00B0\uf0f9\u9095\uf0f9\u90b6\v\n\\\""));
+  b.add(
+      Value("Before\nAfter\r\t\v\f\b\x01\x02/"
+            "\u00B0\uf0f9\u9095\uf0f9\u90b6\v\n\\\""));
   Options options;
   options.escapeControl = true;
   ASSERT_EQ(std::string("\"Before\\nAfter\\r\\t\\u000B\\f\\b\\u0001\\u0002/"
@@ -1958,3 +1959,95 @@ int main(int argc, char* argv[]) {
 
   return RUN_ALL_TESTS();
 }
+
+TEST(DumperLargeDoubleTest, TwoToThePowerOf60Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(ldexp(1.0, 60)));
+  dumper.dump(builder.slice());
+  ASSERT_EQ("1152921504606846976.0", buffer);
+}
+
+TEST(DumperLargeDoubleTest, TwoToThePowerOf60Plus1Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(ldexp(1.0, 60) + 1.0));
+  dumper.dump(builder.slice());
+  ASSERT_EQ("1152921504606846976.0", buffer);
+}
+
+TEST(DumperLargeDoubleTest, MinusTwoToThePowerOf60Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(-ldexp(1.0, 60)));
+  dumper.dump(builder.slice());
+  ASSERT_EQ("-1152921504606846976.0", buffer);
+}
+
+TEST(DumperLargeDoubleTest, MinusTwoToThePowerOf60Plus1Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(-ldexp(1.0, 60) + 1.0));
+  dumper.dump(builder.slice());
+  ASSERT_EQ("-1152921504606846976.0", buffer);
+}
+
+TEST(DumperLargeDoubleTest, TwoToThePowerOf52Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(ldexp(1.0, 52)));
+  dumper.dump(builder.slice());
+  ASSERT_EQ("4503599627370496", buffer);
+}
+
+TEST(DumperLargeDoubleTest, TwoToThePowerOf53Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(ldexp(1.0, 53)));
+  dumper.dump(builder.slice());
+  ASSERT_EQ("9007199254740992.0", buffer);
+}
+
+TEST(DumperLargeDoubleTest, TwoToThePowerOf63Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(ldexp(1.0, 63)));
+  dumper.dump(builder.slice());
+  ASSERT_EQ("9223372036854775808.0", buffer);
+}
+
+TEST(DumperLargeDoubleTest, TwoToThePowerOf64Double) {
+  Options options;
+  std::string buffer;
+  StringSink sink(&buffer);
+  Dumper dumper(&sink, &options);
+  Builder builder;
+  builder.add(Value(ldexp(1.0, 64)));
+  dumper.dump(builder.slice());
+  // Note that this is, strictly speaking, not correct. But since this is
+  // at least 2^64, it will be parsed back to double anywa and then we
+  // get back the actual result. This is a sacrifice we make for performance.
+  ASSERT_EQ("18446744073709552000", buffer);
+}
+


### PR DESCRIPTION
Change dumping of large double values in the area of absolute value
between 2^53 and 2^64. This is to ensure that things are parsed back
to the same value.
