### PR TITLE
Fix fpconv_dtoa when deal neg number

### DIFF
--- a/src/fpconv.cpp
+++ b/src/fpconv.cpp
@@ -235,7 +235,7 @@ static int emit_digits(char* digits, int ndigits, char* dest, int K, bool neg) {
   int exp = absv(K + ndigits - 1);
 
   /* write plain integer */
-  if (K >= 0 && (exp < (ndigits + 7))) {
+  if (K >= 0 && (exp < (ndigits + 7 - neg))) {
     memcpy(dest, digits, ndigits);
     // intentionally fill with '0', not 0 (NUL byte) because
     // we want the string representation of the number zero


### PR DESCRIPTION
In fpconv_dtoa of emit_digits, we shoud check neg. close issue #170 