### PR TITLE
DO NOT MERGE Changed the workflow to be able to support installation of older versions of clang

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -79,16 +79,15 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libunwind-dev
+         # Detect the Ubuntu version codename
+        DIST_CODENAME=$(lsb_release -cs)
         sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         version=${{ matrix.version }}
-        if [[ $version -ge 13 ]]; then
-          sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-$version main"
-        fi
+        sudo add-apt-repository "deb http://apt.llvm.org/$DIST_CODENAME/ llvm-toolchain-$DIST_CODENAME-$version main"
         sudo apt-get update
         sudo apt-get install clang-$version lld libc++-$version-dev libc++abi-$version-dev  
         echo "CC=clang-$version" >> ${GITHUB_ENV}
         echo "CXX=clang++-$version" >> ${GITHUB_ENV}
-        echo "CC=clang-$version" >> ${GITHUB_ENV}
         echo "LDFLAGS=-fuse-ld=lld" >> ${GITHUB_ENV}
     - name: Initialize MSVC ${{ matrix.version }}
       if: startsWith(matrix.os, 'windows-')

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -82,7 +82,7 @@ jobs:
         # Detect the Ubuntu distribution codename
         DIST_CODENAME=$(lsb_release -cs)
         if [[ "$DIST_CODENAME" = "noble" && "$version" -le 12 ]]; then                                                                             
-          DIST_CODENAME="jammy"
+          DIST_CODENAME="focal"
         fi
         sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         version=${{ matrix.version }}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -81,8 +81,8 @@ jobs:
         sudo apt-get install libunwind-dev
         # Detect the Ubuntu distribution codename
         DIST_CODENAME=$(lsb_release -cs)
-        if [[ "$DIST_CODENAME" = "noble" && "$version" -le 12 ]]; then
-  	      DIST_CODENAME="jammy"
+        if [[ "$DIST_CODENAME" = "noble" && "$version" -le 12 ]]; then                                                                             
+          DIST_CODENAME="jammy"
         fi
         sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         version=${{ matrix.version }}

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -79,8 +79,11 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libunwind-dev
-         # Detect the Ubuntu version codename
+        # Detect the Ubuntu distribution codename
         DIST_CODENAME=$(lsb_release -cs)
+	  if [[ "$DIST_CODENAME" = "noble" && "$version" -le 12 ]]; then
+  	  DIST_CODENAME="jammy"
+	fi
         sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         version=${{ matrix.version }}
         sudo add-apt-repository "deb http://apt.llvm.org/$DIST_CODENAME/ llvm-toolchain-$DIST_CODENAME-$version main"

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -81,9 +81,9 @@ jobs:
         sudo apt-get install libunwind-dev
         # Detect the Ubuntu distribution codename
         DIST_CODENAME=$(lsb_release -cs)
-	  if [[ "$DIST_CODENAME" = "noble" && "$version" -le 12 ]]; then
-  	  DIST_CODENAME="jammy"
-	fi
+        if [[ "$DIST_CODENAME" = "noble" && "$version" -le 12 ]]; then
+  	      DIST_CODENAME="jammy"
+        fi
         sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         version=${{ matrix.version }}
         sudo add-apt-repository "deb http://apt.llvm.org/$DIST_CODENAME/ llvm-toolchain-$DIST_CODENAME-$version main"


### PR DESCRIPTION
EDIT: for now, we will wait for an approach, probably to dismiss the tests with older clangs, so this PR remains open as a placeholder as it might be used to apply this approach 


This PR changes the CI workflow for correcting the  error that occurs when tests begin (shown in the screenshot below).
<img width="336" height="254" alt="Screenshot From 2025-09-03r 10-28-32" src="https://github.com/user-attachments/assets/7d21f101-3a36-4600-82b8-6c21557bf184" />
GitHub's ubuntu-latest runner switched to a later Ubuntu version that doesn't support clang 11 and 12 in its default repositories, and these versions are included in our matrix. As can be seen in the screenshot, the package list shows entries the prefix noble which is for Ubuntu 24.04, not jammy jellyfish anymore as in 22.04.
So we have to go to llvm-toolchain repository for the correct Ubuntu version codename to allow apt to install the versions needed. It's ends up being a mix of both distributions, but so far the only solution found.
EDIT: trying now with focal fossa because there's no repository for clang-12 in jammy either
