### PR TITLE
[COR-627]: Fix normalized hash for -0 and +0

### DIFF
--- a/include/velocypack/SliceBase.tpp
+++ b/include/velocypack/SliceBase.tpp
@@ -22,6 +22,7 @@
 /// @author Max Neunhoeffer
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <cmath>
 #include <ostream>
 
 #include "velocypack/velocypack-common.h"
@@ -180,8 +181,11 @@ uint64_t SliceBase<DerivedType, SliceType>::normalizedHash(
   uint64_t value;
 
   if (isNumber()) {
-    // upcast integer values to double
+    // upcast integer values to double; normalize -0.0 to 0.0 (hash/equality invariant)
     double v = getNumericValue<double>();
+    if (std::signbit(v) && v == 0.0) {
+      v = 0.0;
+    }
     value = VELOCYPACK_HASH(&v, sizeof(v), seed);
   } else if (isArray()) {
     // normalize arrays by hashing array length and iterating
@@ -221,8 +225,11 @@ uint32_t SliceBase<DerivedType, SliceType>::normalizedHash32(
   uint32_t value;
 
   if (isNumber()) {
-    // upcast integer values to double
+    // upcast integer values to double; normalize -0.0 to 0.0 (hash/equality invariant)
     double v = getNumericValue<double>();
+    if (std::signbit(v) && v == 0.0) {
+      v = 0.0;
+    }
     value = VELOCYPACK_HASH32(&v, sizeof(v), seed);
   } else if (isArray()) {
     // normalize arrays by hashing array length and iterating

--- a/tests/testsSlice.cpp
+++ b/tests/testsSlice.cpp
@@ -2379,6 +2379,19 @@ TYPED_TEST(SliceTest, NormalizedHashDouble) {
   ASSERT_EQ(13690116699997059692ULL, b2.slice().normalizedHash());
 }
 
+TYPED_TEST(SliceTest, NormalizedHashSignedZero) {
+  Builder bn;
+  bn.add(Value(-0.0));
+  TypeParam neg_zero = bn.slice();
+
+  Builder bp;
+  bp.add(Value(0.0));
+  TypeParam pos_zero = bp.slice();
+
+  ASSERT_EQ(neg_zero.normalizedHash(), pos_zero.normalizedHash());
+  ASSERT_EQ(neg_zero.normalizedHash32(), pos_zero.normalizedHash32());
+}
+
 TYPED_TEST(SliceTest, NormalizedHashArray) {
   Options options;
 
@@ -2565,6 +2578,19 @@ TYPED_TEST(SliceTest, NormalizedHashDouble) {
 
   ASSERT_EQ(65589186907022834ULL, b1.slice().normalizedHash());
   ASSERT_EQ(65589186907022834ULL, b2.slice().normalizedHash());
+}
+
+TYPED_TEST(SliceTest, NormalizedHashSignedZero) {
+  Builder bn;
+  bn.add(Value(-0.0));
+  TypeParam neg_zero = bn.slice();
+
+  Builder bp;
+  bp.add(Value(0.0));
+  TypeParam pos_zero = bp.slice();
+
+  ASSERT_EQ(neg_zero.normalizedHash(), pos_zero.normalizedHash());
+  ASSERT_EQ(neg_zero.normalizedHash32(), pos_zero.normalizedHash32());
 }
 
 TYPED_TEST(SliceTest, NormalizedHashArray) {


### PR DESCRIPTION
## Summary

normalizedHash and normalizedHash32 upcast numbers to double and hash the raw bit pattern directly. Since -0.0 and +0.0 have different bit patterns but “==” considers them equal, two values that are semantically equal would produce different hash values  (breaking the contract that a == b must imply hash(a) == hash(b)). This could cause lookups in hash maps to silently miss entries stored under the opposite zero representation. 
Ticket https://arangodb.atlassian.net/browse/COR-627